### PR TITLE
[ Feature ] ExoPlayer에서 Media3로의 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-# Created by https://www.toptal.com/developers/gitignore/api/windows,android,androidstudio,kotlin,java
-# Edit at https://www.toptal.com/developers/gitignore?templates=windows,android,androidstudio,kotlin,java
+# Created by https://www.toptal.com/developers/gitignore/api/android,androidstudio,kotlin,java
+# Edit at https://www.toptal.com/developers/gitignore?templates=android,androidstudio,kotlin,java
 
 ### Android ###
 # Gradle files
 .gradle/
+gradlew
+gradlew.bat
 build/
 
 # Local configuration file (sdk path, etc)
@@ -80,38 +82,22 @@ replay_pid*
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 
-### Windows ###
-# Windows thumbnail cache files
-Thumbs.db
-Thumbs.db:encryptable
-ehthumbs.db
-ehthumbs_vista.db
-
-# Dump file
-*.stackdump
-
-# Folder config file
-[Dd]esktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
-
-# Windows Installer files
-*.cab
-*.msi
-*.msix
-*.msm
-*.msp
-
-# Windows shortcuts
-*.lnk
-
 ### AndroidStudio ###
 # Covers files to be ignored for android development using Android Studio.
 
 # Built application files
+*.apk
 *.ap_
 *.aab
+/*/*.apk
+/*/*.ap_
+/*/*.aab
+**/*.apk
+**/*.ap_
+**/*.aab
+app-release.aab
+app/release/app-release.aab
+.app/release/app-release.aab
 
 # Files for the ART/Dalvik VM
 *.dex
@@ -151,6 +137,9 @@ proguard/
 
 # Google Services (e.g. APIs or Firebase)
 # google-services.json
+google-services.json
+app/src/google-services.json
+.app/src/google-services.json
 
 # Android Patch
 
@@ -171,10 +160,13 @@ obj/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/.name
+.idea/kotlinc.xml
+.idea/misc.xml
 .idea/compiler.xml
 .idea/copyright/profiles_settings.xml
 .idea/encodings.xml
 .idea/misc.xml
+.idea/deploymentTargetDropDown.xml
 .idea/modules.xml
 .idea/scopes/scope_settings.xml
 .idea/dictionaries
@@ -189,6 +181,15 @@ obj/
 .idea/gradle.xml
 .idea/jarRepositories.xml
 .idea/navEditor.xml
+
+.app/config/detekt.yml
+.app/config/lint.yml
+.app/config/lint/lint-baseline.yml
+.app/config/detekt.yml
+keystore_base64.txt
+google_play_app_signing_key_hash.txt
+private_key.pepk
+upload_certificate.pem
 
 # Legacy Eclipse project files
 .classpath
@@ -223,4 +224,7 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
-# End of https://www.toptal.com/developers/gitignore/api/windows,android,androidstudio,kotlin,java
+# End of https://www.toptal.com/developers/gitignore/api/android,androidstudio,kotlin,java
+/app/config/detekt.yml
+/app/config/lint/lint.xml
+/app/config/lint/lint-baseline.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,11 +84,10 @@ dependencies {
     kapt("androidx.room:room-compiler:$room_version")
     testImplementation("androidx.room:room-testing:$room_version")
 
-    // ExoPlayer
-    implementation("com.google.android.exoplayer:exoplayer:2.19.1")
-    implementation("com.google.android.exoplayer:exoplayer-core:2.19.1")
-    implementation("com.google.android.exoplayer:exoplayer-dash:2.19.1")
-    implementation("com.google.android.exoplayer:exoplayer-ui:2.19.1")
+    // Media3 - ExoPlayer
+    implementation("androidx.media3:media3-exoplayer:1.2.0")
+    implementation("androidx.media3:media3-exoplayer-dash:1.2.0")
+    implementation("androidx.media3:media3-ui:1.2.0")
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,19 +3,21 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.hero.ziggymusic">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
+        android:name=".ZiggyMusicApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:name=".ZiggyMusicApp"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
@@ -24,7 +26,8 @@
         <service
             android:name=".service.MusicService"
             android:enabled="true"
-            android:exported="false" >
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
             <intent-filter>
                 <action android:name="com.hero.ziggymusic.INITPLAY" />
                 <action android:name="com.hero.ziggymusic.PLAY_OR_PAUSE" />

--- a/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
@@ -1,10 +1,8 @@
 package com.hero.ziggymusic
 
 import android.app.Application
-import androidx.lifecycle.ViewModelProvider.NewInstanceFactory.Companion.instance
-import com.google.android.exoplayer2.ExoPlayer
+import androidx.media3.exoplayer.ExoPlayer
 import dagger.hilt.android.HiltAndroidApp
-import kotlin.text.Typography.dagger
 
 @HiltAndroidApp
 class ZiggyMusicApp : Application() {

--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.hero.ziggymusic.database.local
 
 import android.app.Application
 import android.provider.MediaStore
-import android.util.Log
 import androidx.lifecycle.LiveData
 import com.hero.ziggymusic.database.music.dao.MusicFileDao
 import com.hero.ziggymusic.database.music.dao.PlaylistMusicDao

--- a/app/src/main/java/com/hero/ziggymusic/ext/ImageBindingAdapterExt.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ext/ImageBindingAdapterExt.kt
@@ -3,10 +3,6 @@ package com.hero.ziggymusic.ext
 import android.net.Uri
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
-import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
-import com.hero.ziggymusic.R
-import com.hero.ziggymusic.database.music.entity.MusicModel
 
 @BindingAdapter("imageURI")
 fun ImageView.setAlbumImageURI(uri: Uri?) {

--- a/app/src/main/java/com/hero/ziggymusic/ext/RecyclerBindingAdapterExt.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ext/RecyclerBindingAdapterExt.kt
@@ -1,7 +1,5 @@
 package com.hero.ziggymusic.ext
 
-import android.text.method.TextKeyListener.clear
-import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hero.ziggymusic.database.music.entity.MusicModel

--- a/app/src/main/java/com/hero/ziggymusic/ext/TextBindingAdapterExt.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ext/TextBindingAdapterExt.kt
@@ -3,9 +3,10 @@ package com.hero.ziggymusic.ext
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 @BindingAdapter("duration")
 fun TextView.setDuration(duration: Long) {
-    val simpleDateFormat = SimpleDateFormat("mm:ss")
+    val simpleDateFormat = SimpleDateFormat("mm:ss", Locale.getDefault())
     text = simpleDateFormat.format(duration)
 }

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
-import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Binder
 import android.os.Build
@@ -18,15 +17,12 @@ import android.util.Log
 import android.widget.RemoteViews
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.common.eventbus.Subscribe
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.ZiggyMusicApp
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.event.Event
 import com.hero.ziggymusic.event.EventBus
-import com.hero.ziggymusic.view.main.MainActivity
 import com.hero.ziggymusic.view.main.player.PlayerFragment
 import java.io.IOException
 import kotlin.system.exitProcess

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -16,10 +16,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.viewpager2.widget.ViewPager2
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.navigation.NavigationBarView
 import com.hero.ziggymusic.R

--- a/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.bumptech.glide.Glide.init
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.hero.ziggymusic.view.main.player.PlayerFragment
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -1,10 +1,7 @@
 package com.hero.ziggymusic.view.main.musiclist
 
-import android.content.ComponentName
 import android.content.Intent
-import android.content.ServiceConnection
 import android.os.Bundle
-import android.os.IBinder
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -19,7 +16,6 @@ import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.FragmentMusicListBinding
-import com.hero.ziggymusic.event.Event
 import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.ext.playMusic
 import com.hero.ziggymusic.service.MusicService

--- a/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistAdapter.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistAdapter.kt
@@ -1,7 +1,5 @@
 package com.hero.ziggymusic.view.main.myplaylist
 
-import android.net.Uri
-import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistFragment.kt
@@ -15,7 +15,6 @@ import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.FragmentMyPlaylistBinding
-import com.hero.ziggymusic.event.Event
 import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.ext.playMusic
 import com.hero.ziggymusic.service.MusicService

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -6,16 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
+import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.hero.ziggymusic.R
@@ -25,7 +26,6 @@ import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.FragmentPlayerBinding
 import com.hero.ziggymusic.event.Event
 import com.hero.ziggymusic.event.EventBus
-
 import com.hero.ziggymusic.view.main.player.viewmodel.PlayerViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -284,7 +284,7 @@ class PlayerFragment : Fragment(), View.OnClickListener {
     }
 
 
-    private fun playMusic(musicList: List<MusicModel>, nowPlayMusic: MusicModel?) {
+    @OptIn(UnstableApi::class) private fun playMusic(musicList: List<MusicModel>, nowPlayMusic: MusicModel?) {
         if (nowPlayMusic != null) {
             currentMusic = nowPlayMusic
             playerModel.updateCurrentMusic(nowPlayMusic)

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -127,7 +127,7 @@
             android:textSize="@dimen/title_text_size"
             app:layout_constraintTop_toBottomOf="@+id/tv_song_artist" />
 
-        <com.google.android.exoplayer2.ui.PlayerView
+        <androidx.media3.ui.PlayerView
             android:id="@+id/v_player"
             android:layout_width="0dp"
             android:layout_height="100dp"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@ plugins {
     id("com.google.dagger.hilt.android") version '2.48.1' apply false
 }
 
-tasks.register('clean', Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
ExoPlayer가 AndroidX JetpackMedia3로 마이그레이션됨에 따라 이에 맞추었다.

- Media3-ExoPlayer로 마이그레이션
- 불필요한 import 제거
- AndroidManifest에 Foreground 관련 설정을 추가
- SimpleDateFormat에 Locale 인자 추가
- gitignore 수정