### PR TITLE
[ Chore ] Android 14 (API 수준 34) 이상을 타겟하기 위한 이미지 및 동영상 권한 설정 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 


### PR DESCRIPTION
- Android 14 (API 수준 34) 이상을 타겟팅하기 위해 AndroidManifest에 라이브러리의 특정 이미지 및 동영상 권한 설정 추가