### PR TITLE
[ Hotfix ] Notification과 플레이어 동기화 오류 해결

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -94,19 +94,24 @@ class MusicService : MediaLibraryService() {
 
         when(intent?.action) {
             PLAY -> { // Notification 에서 재생 / 일시 정지 버튼을 누를 시
-                Log.d("onStartCommand", "PLAY: ${player.isPlaying}")
-                EventBus.getInstance().post(Event("PLAY"))
+                if (!player.isPlaying) {
+                    Log.d("onStartCommand", "PLAY")
+                    player.play()
+                }
             }
             PAUSE -> { // Notification 에서 재생 / 일시 정지 버튼을 누를 시
-                Log.d("onStartCommand", "PAUSE: ${player.isPlaying}")
-                EventBus.getInstance().post(Event("PAUSE"))
+                if (player.isPlaying) {
+                    Log.d("onStartCommand", "PAUSE")
+                    player.pause()
+                }
             }
             SKIP_PREV -> { // Notification 에서 이전 곡 버튼을 누를 시
-                Log.d("SKIP_PREV", "onStartCommand: $player")
-                EventBus.getInstance().post(Event("SKIP_PREV"))
+                Log.d("onStartCommand", "SKIP_PREV")
+                player.seekToPrevious()
             }
             SKIP_NEXT -> { // Notification 에서 다음 곡 버튼을 누를 시
-                EventBus.getInstance().post(Event("SKIP_NEXT"))
+                Log.d("onStartCommand", "SKIP_NEXT")
+                player.seekToNext()
             }
             CLOSE -> { // Notification 에서 닫기 버튼 누를 시
                 stopSelf()
@@ -143,10 +148,10 @@ class MusicService : MediaLibraryService() {
                 player.pause()
             }
             "SKIP_PREV" -> {
-
+                player.seekToPrevious()
             }
             "SKIP_NEXT" -> {
-
+                player.seekToNext()
             }
         }
     }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -550,7 +550,10 @@ class PlayerFragment : Fragment(), View.OnClickListener {
         syncPlayerUi()
         startSeekUpdates() // 포그라운드 진입 직후 진행바 시작
 
-        player.addListener(object : Player.Listener {
+        // 화면 회전/재진입 등으로 initPlayView()가 여러 번 호출되면, 기존 리스너 위에 새 리스너가 계속 추가되어 콜백이 중복 실행됨 -> 이를 방지
+        playerListener?.let { player.removeListener(it) }
+
+        playerListener = object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 super.onIsPlayingChanged(isPlaying)
 
@@ -582,14 +585,16 @@ class PlayerFragment : Fragment(), View.OnClickListener {
                 // 재생 반복 해제 모드 & 마지막 트랙 재생이 끝났을 때 -> 첫번째 트랙으로 이동 & 일시정지 상태
                 if (player.repeatMode == Player.REPEAT_MODE_OFF &&
                     player.currentMediaItemIndex == player.mediaItemCount - 1 &&
-                    state == Player.STATE_ENDED) {
-
+                    state == Player.STATE_ENDED
+                ) {
                     player.seekTo(0, 0)
                     updatePlayerView(playerModel.currentMusic)
                     player.pause()
                 }
             }
-        })
+        }
+
+        player.addListener(playerListener!!)
     }
 
     private fun syncCollapsedPlayerWithNotification() {


### PR DESCRIPTION
# PR 내용
- 앱이 백그라운드에 있을 때 Notification을 클릭하면 앱이 비정상 종료되는 오류 해결
-  앱이 백그라운드에 있을 때 Notification을 클릭하면 Collapsed 상태의 플레이어에 음원 메타데이터(제목, 아티스트)가 반영되지 않는 오류 수정
-  앱이 백그라운드에 있을 때 Notification을 클릭하면 Collapsed 상태의 플레이어의 SeekBar가 진행되지 않는 오류 수정
-  앱이 백그라운드에 있을 때 Notification을 클릭하고 플레이어의 재생, 다음 트랙 이동 버튼을 클릭한 동작이 Notification에 반영되지 않는 오류 수정