### PR TITLE
[ Hotfix ] 플레이어 버그 수정

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -178,6 +178,12 @@ class PlayerFragment : Fragment() {
             vm.state
                 .collect { state ->
                     playerMotionManager.changeState(state)
+
+                    if (state == PlayerMotionManager.State.EXPANDED) {
+                        startSeekUpdates()
+                    } else {
+                        stopSeekUpdates()
+                    }
                 }
         }
 
@@ -413,6 +419,10 @@ class PlayerFragment : Fragment() {
 
         val view = binding.root
         view.removeCallbacks(updateSeekRunnable)
+
+        if (player.isPlaying) {
+            view.postDelayed(updateSeekRunnable, 1000L)
+        }
     }
 
     private fun updateSeekUi(duration: Long, position: Long) {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -365,7 +365,7 @@ class PlayerFragment : Fragment() {
                 binding.ivShuffleMode.setImageResource(R.drawable.ic_shuffle_off)
             } else { // 셔플 모드가 Off일 때
                 player.shuffleModeEnabled = true
-                player.setShuffleOrder(ShuffleOrder.DefaultShuffleOrder(playerViewModel.musicList.value.orEmpty().size, Random.nextLong()))
+                player.shuffleOrder = ShuffleOrder.DefaultShuffleOrder(playerViewModel.musicList.value.orEmpty().size, Random.nextLong())
                 binding.ivShuffleMode.setImageResource(R.drawable.ic_shuffle_on)
             }
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -191,7 +191,6 @@ class PlayerFragment : Fragment() {
             vm.musicList.observe(viewLifecycleOwner) { musicList ->
                 if (_binding == null) return@observe
 
-                Log.d("initViewModel", "playerModel: $playerModel")
                 playerModel.replaceMusicList(musicList)
 
                 // 현재 ExoPlayer가 재생 중인 곡의 id를 우선 사용

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -127,12 +127,7 @@ class PlayerFragment : Fragment() {
             playerBottomSheetManager
         )
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            playerViewModel.state
-                .collect { state ->
-                    playerMotionManager.changeState(state)
-                }
-        }
+
 
         // 현재 재생 중인 곡 정보를 즉시 UI에 반영
         player.currentMediaItem?.mediaId?.let { mediaId ->
@@ -190,6 +185,13 @@ class PlayerFragment : Fragment() {
     }
 
     private fun initViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            playerViewModel.state
+                .collect { state ->
+                    playerMotionManager.changeState(state)
+                }
+        }
+
         viewLifecycleOwner.lifecycleScope.launch {
             playerViewModel.musicList.observe(viewLifecycleOwner) { musicList ->
                 if (_binding == null) return@observe

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -515,15 +515,19 @@ class PlayerFragment : Fragment() {
 
     private fun toggleRepeatModeIcon() {
         binding.ivRepeatMode.setOnClickListener {
-            if (player.repeatMode == Player.REPEAT_MODE_OFF) { // 반복 재생 모드 해제 상태일 때
-                player.repeatMode = Player.REPEAT_MODE_ALL
-                binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_all_on)
-            } else if (player.repeatMode == Player.REPEAT_MODE_ALL) { // 전 곡 반복 재생 모드일 때
-                player.repeatMode = Player.REPEAT_MODE_ONE
-                binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_one_on)
-            } else { // 한 곡 반복 재생 모드일 때
-                player.repeatMode = Player.REPEAT_MODE_OFF
-                binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_all)
+            when (player.repeatMode) {
+                Player.REPEAT_MODE_OFF -> { // 반복 재생 모드 해제 상태일 때
+                    player.repeatMode = Player.REPEAT_MODE_ALL
+                    binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_all_on)
+                }
+                Player.REPEAT_MODE_ALL -> { // 전 곡 반복 재생 모드일 때
+                    player.repeatMode = Player.REPEAT_MODE_ONE
+                    binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_one_on)
+                }
+                else -> { // 한 곡 반복 재생 모드일 때
+                    player.repeatMode = Player.REPEAT_MODE_OFF
+                    binding.ivRepeatMode.setImageResource(R.drawable.ic_repeat_all)
+                }
             }
         }
     }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -448,8 +448,6 @@ class PlayerFragment : Fragment() {
                 it.id == musicId
             }
 
-        Log.d("changeMusic", "findIndex: $findIndex")
-
         if (findIndex != -1) {
             player.seekTo(findIndex, 0)
             player.play()
@@ -523,12 +521,10 @@ class PlayerFragment : Fragment() {
         }
 
         binding.ivNext.setOnClickListener {
-            Log.d("PlayerFragment", "Next 버튼 클릭됨")
             sendServiceAction(SKIP_NEXT)
         }
 
         binding.ivPrevious.setOnClickListener {
-            Log.d("PlayerFragment", "Prev 버튼 클릭됨")
             sendServiceAction(SKIP_PREV)
         }
     }
@@ -567,7 +563,6 @@ class PlayerFragment : Fragment() {
                 val newMusicKey: String = mediaItem?.mediaId ?: return
                 playerModel.changedMusic(newMusicKey)
 
-                Log.d("onMediaItemTransition", "playerModel.currentMusic: ${playerModel.currentMusic}")
                 updatePlayerView(playerModel.currentMusic)
 
                 // 트랙 전환 시 제목/아티스트/아트 동기화

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -118,13 +118,7 @@ class PlayerFragment : Fragment() {
         initSeekBar()
         initPlayerManager()
 
-        player.currentMediaItem?.mediaId?.let { mediaId ->
-            val music = playerViewModel.musicList.value?.find { it.id == mediaId }
-            if (music != null) {
-                playerModel.updateCurrentMusic(music)
-                updatePlayerView(music)
-            }
-        }
+
 
         initListeners()
     }
@@ -214,6 +208,14 @@ class PlayerFragment : Fragment() {
                 if (player.currentMediaItem == null && nowMusic != null) {
                     playMusic(musicList, nowMusic)
                 }
+            }
+        }
+
+        player.currentMediaItem?.mediaId?.let { mediaId ->
+            val music = playerViewModel.musicList.value?.find { it.id == mediaId }
+            if (music != null) {
+                playerModel.updateCurrentMusic(music)
+                updatePlayerView(music)
             }
         }
     }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -724,15 +724,6 @@ class PlayerFragment : Fragment() {
             scheduleBluetoothUpdate()
         }
 
-        // 현재 재생 중인 곡 정보를 즉시 UI에 반영
-        player.currentMediaItem?.mediaId?.let { mediaId ->
-            val music = playerViewModel.musicList.value?.find { it.id == mediaId }
-            if (music != null) {
-                playerModel.updateCurrentMusic(music)
-                updatePlayerView(music)
-            }
-        }
-
         // 포그라운드 복귀 시 반드시 루프 재시작
         startSeekUpdates()
         startVolumeObserver()   // 하드웨어 볼륨 변경 감지 시작

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -69,7 +69,7 @@ class PlayerFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var playerModel: PlayerModel = PlayerModel.getInstance()
-    private val playerViewModel by viewModels<PlayerViewModel>()
+    private val vm by viewModels<PlayerViewModel>()
     private var playerListener: Player.Listener? = null
 
     @Inject
@@ -128,12 +128,12 @@ class PlayerFragment : Fragment() {
 
     private fun initListeners() {
         binding.root.setOnClickListener {
-            val toggleState = when (playerViewModel.state.value) {
+            val toggleState = when (vm.state.value) {
                 PlayerMotionManager.State.COLLAPSED -> PlayerMotionManager.State.EXPANDED
                 PlayerMotionManager.State.EXPANDED -> PlayerMotionManager.State.COLLAPSED
             }
 
-            playerViewModel.changeState(toggleState)
+            vm.changeState(toggleState)
         }
 
         toggleVolumeIcon()
@@ -149,11 +149,11 @@ class PlayerFragment : Fragment() {
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
                     when (newState) {
                         BottomSheetBehavior.STATE_EXPANDED -> {
-                            playerViewModel.changeState(PlayerMotionManager.State.EXPANDED)
+                            vm.changeState(PlayerMotionManager.State.EXPANDED)
                         }
 
                         BottomSheetBehavior.STATE_COLLAPSED -> {
-                            playerViewModel.changeState(PlayerMotionManager.State.COLLAPSED)
+                            vm.changeState(PlayerMotionManager.State.COLLAPSED)
                         }
 
                         BottomSheetBehavior.STATE_HIDDEN -> {
@@ -175,14 +175,14 @@ class PlayerFragment : Fragment() {
 
     private fun initViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
-            playerViewModel.state
+            vm.state
                 .collect { state ->
                     playerMotionManager.changeState(state)
                 }
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            playerViewModel.musicList.observe(viewLifecycleOwner) { musicList ->
+            vm.musicList.observe(viewLifecycleOwner) { musicList ->
                 if (_binding == null) return@observe
 
                 Log.d("initViewModel", "playerModel: $playerModel")
@@ -208,7 +208,7 @@ class PlayerFragment : Fragment() {
         }
 
         player.currentMediaItem?.mediaId?.let { mediaId ->
-            val music = playerViewModel.musicList.value?.find { it.id == mediaId }
+            val music = vm.musicList.value?.find { it.id == mediaId }
             if (music != null) {
                 playerModel.updateCurrentMusic(music)
                 updatePlayerView(music)
@@ -217,7 +217,7 @@ class PlayerFragment : Fragment() {
     }
 
     fun changeMusic(musicId: String) {
-        val findIndex = playerViewModel.musicList.value.orEmpty()
+        val findIndex = vm.musicList.value.orEmpty()
             .indexOfFirst {
                 it.id == musicId
             }
@@ -507,7 +507,7 @@ class PlayerFragment : Fragment() {
                 binding.ivShuffleMode.setImageResource(R.drawable.ic_shuffle_off)
             } else { // 셔플 모드가 Off일 때
                 player.shuffleModeEnabled = true
-                player.shuffleOrder = ShuffleOrder.DefaultShuffleOrder(playerViewModel.musicList.value.orEmpty().size, Random.nextLong())
+                player.shuffleOrder = ShuffleOrder.DefaultShuffleOrder(vm.musicList.value.orEmpty().size, Random.nextLong())
                 binding.ivShuffleMode.setImageResource(R.drawable.ic_shuffle_on)
             }
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -339,8 +339,8 @@ class PlayerFragment : Fragment() {
 
                 updatePlayerView(playerModel.currentMusic)
 
-                // 트랙 전환 시 제목/아티스트/아트 동기화
-                syncCollapsedPlayerWithNotification()
+                // 트랙 전환 시 제목/아티스트/앨범 아트, 재생/일시정지 아이콘 동기화
+                syncPlayerUi()
             }
 
             // 재생, 재생 완료, 버퍼링 상태 ...
@@ -372,19 +372,6 @@ class PlayerFragment : Fragment() {
         }
 
         player.addListener(playerListener!!)
-    }
-
-    private fun syncCollapsedPlayerWithNotification() {
-        // 현재 트랙을 우선 ExoPlayer에서, 없으면 PlayerModel에서 조회
-        val currentMusic = playerModel.currentMusic
-
-        currentMusic?.let { music ->
-            // 프로젝트의 기존 메서드로 텍스트/아트 일괄 반영
-            updatePlayerView(music)
-        }
-
-        // 재생/일시정지 아이콘 및 비주얼라이저 동기화
-        syncPlayerUi()
     }
 
     private fun syncPlayerUi() {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -139,7 +139,6 @@ class PlayerFragment : Fragment() {
         toggleVolumeIcon()
         toggleRepeatModeIcon()
         toggleShuffleModeIcon()
-        setupBluetoothMonitoring()
     }
 
     private fun initPlayerManager() {
@@ -568,35 +567,6 @@ class PlayerFragment : Fragment() {
                 }
             }
         }
-    }
-
-    private fun setupBluetoothMonitoring() {
-        // 블루투스 아이콘 클릭 리스너 - 테스트용 토글 기능
-        binding.bluetooth.setOnClickListener {
-            // 테스트용: 클릭할 때마다 아이콘 토글
-            val currentDrawable = binding.bluetooth.drawable
-            val airplayDrawable = ContextCompat.getDrawable(requireContext(), R.drawable.ic_airplay)
-            val airpodsDrawable = ContextCompat.getDrawable(requireContext(), R.drawable.ic_airpods)
-
-            if (airplayDrawable != null && airpodsDrawable != null && currentDrawable != null) {
-                val currentBitmap = drawableToBitmap(currentDrawable)
-                val airplayBitmap = drawableToBitmap(airplayDrawable)
-
-                if (areBitmapsEqual(currentBitmap, airplayBitmap)) {
-                    binding.bluetooth.setImageResource(R.drawable.ic_airpods)
-                    Log.d("Bluetooth", "Manual toggle: switched to airpods icon")
-                } else {
-                    binding.bluetooth.setImageResource(R.drawable.ic_airplay)
-                    Log.d("Bluetooth", "Manual toggle: switched to airplay icon")
-                }
-            }
-        }
-
-        // 초기 블루투스 상태 체크 및 아이콘 설정
-        updateBluetoothIcon()
-
-        // 주기적으로 블루투스 상태 업데이트
-        scheduleBluetoothUpdate()
     }
 
     private fun updateBluetoothIcon() {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -739,10 +739,11 @@ class PlayerFragment : Fragment() {
     }
 
     override fun onDestroyView() {
-        // Detach player from view to avoid leaking the surface
+        // 리스너 참조로 인한 메모리/수명 누수 방지
         playerListener?.let { player.removeListener(it) }
         playerListener = null
 
+        // Surface 리소스 누수(Fragment의 View가 파괴된 뒤에도 플레이어가 그 Surface를 붙잡고 있어 해제되지 않는 상황)를 방지하기 위해 뷰에서 플레이어를 분리
         _binding?.vPlayer?.player = null
         stopSeekUpdates()
         binding.root.removeCallbacks(updateBluetoothRunnable)

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -113,13 +113,10 @@ class PlayerFragment : Fragment() {
 
         initAudioManager()
         initPlayView()
-        initViewModel()
         initPlayControlButtons()
         initSeekBar()
         initPlayerManager()
-
-
-
+        initViewModel()
         initListeners()
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -751,12 +751,6 @@ class PlayerFragment : Fragment() {
         super.onDestroyView()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-
-        _binding = null
-    }
-
     private fun scheduleBluetoothUpdate() {
         if (_binding == null) return
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -62,6 +62,7 @@ import javax.inject.Inject
 import kotlin.math.max
 import kotlin.random.Random
 import androidx.core.graphics.createBitmap
+import kotlin.compareTo
 
 @AndroidEntryPoint
 class PlayerFragment : Fragment() {
@@ -584,8 +585,18 @@ class PlayerFragment : Fragment() {
                     player.currentMediaItemIndex == player.mediaItemCount - 1 &&
                     state == Player.STATE_ENDED
                 ) {
+                    // 자동 재생 방지
+                    player.playWhenReady = false
+
+                    // 첫 트랙으로 이동
                     player.seekTo(0, 0)
-                    updatePlayerView(playerModel.currentMusic)
+
+                    // PlayerModel 및 UI 동기화
+                    if (player.mediaItemCount > 0) {
+                        val firstId = player.getMediaItemAt(0).mediaId
+                        playerModel.changedMusic(firstId)
+                        updatePlayerView(playerModel.currentMusic)
+                    }
                     player.pause()
                 }
             }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -62,7 +62,6 @@ import javax.inject.Inject
 import kotlin.math.max
 import kotlin.random.Random
 import androidx.core.graphics.createBitmap
-import kotlin.compareTo
 
 @AndroidEntryPoint
 class PlayerFragment : Fragment() {
@@ -120,16 +119,8 @@ class PlayerFragment : Fragment() {
         initViewModel()
         initPlayControlButtons()
         initSeekBar()
-        initPlayerBottomSheetManager()
+        initPlayerManager()
 
-        playerMotionManager = PlayerMotionManager(
-            binding.constraintLayout,
-            playerBottomSheetManager
-        )
-
-
-
-        // 현재 재생 중인 곡 정보를 즉시 UI에 반영
         player.currentMediaItem?.mediaId?.let { mediaId ->
             val music = playerViewModel.musicList.value?.find { it.id == mediaId }
             if (music != null) {
@@ -157,7 +148,7 @@ class PlayerFragment : Fragment() {
         setupBluetoothMonitoring()
     }
 
-    private fun initPlayerBottomSheetManager() {
+    private fun initPlayerManager() {
         playerBottomSheetManager = PlayerBottomSheetManager(
             viewLifecycleOwner.lifecycle,
             binding.constraintLayout,
@@ -181,6 +172,11 @@ class PlayerFragment : Fragment() {
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {
                 }
             }
+        )
+
+        playerMotionManager = PlayerMotionManager(
+            binding.constraintLayout,
+            playerBottomSheetManager
         )
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -111,10 +111,7 @@ class PlayerFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
-        previousVolume = currentVolume
-
+        initAudioManager()
         initPlayView()
         initViewModel()
         initPlayControlButtons()
@@ -130,6 +127,12 @@ class PlayerFragment : Fragment() {
         }
 
         initListeners()
+    }
+
+    private fun initAudioManager() {
+        audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+        previousVolume = currentVolume
     }
 
     private fun initListeners() {

--- a/app/src/main/res/xml/player_motion_scene.xml
+++ b/app/src/main/res/xml/player_motion_scene.xml
@@ -102,6 +102,7 @@
             android:id="@+id/sbPlayer"
             android:layout_width="0dp"
             android:layout_height="@dimen/seekbar_player_height"
+            android:visibility="gone"
             android:progressBackgroundTint="@color/teal_200"
             motion:layout_constraintEnd_toEndOf="parent"
             motion:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/xml/player_motion_scene.xml
+++ b/app/src/main/res/xml/player_motion_scene.xml
@@ -100,13 +100,7 @@
 
         <Constraint
             android:id="@+id/sbPlayer"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/seekbar_player_height"
-            android:visibility="gone"
-            android:progressBackgroundTint="@color/teal_200"
-            motion:layout_constraintEnd_toEndOf="parent"
-            motion:layout_constraintStart_toStartOf="parent"
-            motion:layout_constraintTop_toTopOf="parent" />
+            android:visibility="gone" />
 
         <Constraint
             android:id="@+id/tvCurrentPlayTime"


### PR DESCRIPTION
# PR 내용
- Collapsed 상태의 플레이어에는 SbPlayer를 제거
    - 이에 따라 Expanded 상태의 플레이어의 sbPlayer가 progress되지 않는 버그 수정
- 블루투스 모니터링 기능 제거하여 리소스 낭비 방지
- repeatMode(반복 모드)가 전체 반복일 때 마지막 트랙 재생이 끝나면 첫번째 트랙으로 이동하고 자동 재생되지 않도록 기능 수정
- 코드 중복을 방지하기 위해 syncCollapsedPlayerWithNotification 메서드를 제거하고 syncPlayerUi 메서드로 대체
- PlayerViewModel 인스턴스명을 vm으로 수정
- onViewCreated 메서드 내의 로직을 별도의 메서드로 분리하고 메서드 순서를 변경
- Ktx를 적용하여 setter 함수(setShuffleOrder)를 프로퍼티로 대체
- 불필요한 onDestroy 메서드 제거
- 메서드를 순서를 변경하여 전체 코드 정리
- toggleRepeatModeIcon 메서드에서 if-else문을 when문으로 대체
- 불필요한 Log 제거
- 일부 영어로 된 주석을 한국어로 수정