### PR TITLE
[ Refactor ] UI 관련 로직 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.isGone
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
@@ -100,12 +99,7 @@ class MainActivity : AppCompatActivity(),
     private fun initListeners() {
         binding.ivBack.setOnClickListener {
             supportFragmentManager.popBackStack()
-
-            binding.ivBack.isInvisible = true
-            binding.ivSetting.isVisible = true
-            binding.ivSetting.isEnabled = true
-
-            binding.tvMainTitle.text = title
+            vm.navigateBack()
         }
 
         binding.ivSetting.setOnClickListener {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -50,7 +50,6 @@ class MainActivity : AppCompatActivity(),
 
     private lateinit var binding: ActivityMainBinding
     private val vm by viewModels<MainViewModel>()
-    private var title: String = ""
 
     @Inject
     lateinit var player: ExoPlayer
@@ -194,8 +193,6 @@ class MainActivity : AppCompatActivity(),
 
     @Subscribe
     fun doEvent(event: Event) {
-        val currentMusic = playerModel.currentMusic
-
         when(event.getEvent()) {
             "PLAY_NEW_MUSIC" -> { // 새로운 음원이 재생
                 musicServiceStart()

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -41,6 +41,7 @@ import javax.inject.Inject
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import com.hero.ziggymusic.view.main.model.MainTitle
 import com.hero.ziggymusic.view.main.musiclist.MusicListFragment
 import com.hero.ziggymusic.view.main.myplaylist.MyPlaylistFragment
 
@@ -97,8 +98,6 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun initListeners() {
-        val titleArr = resources.getStringArray(R.array.title_array)
-
         binding.ivBack.setOnClickListener {
             supportFragmentManager.popBackStack()
 
@@ -119,11 +118,7 @@ class MainActivity : AppCompatActivity(),
                 .commit()
             supportFragmentManager.executePendingTransactions()
 
-            binding.ivBack.isVisible = true
-            binding.ivSetting.isInvisible = true
-            binding.ivSetting.isEnabled = false
-
-            binding.tvMainTitle.text = titleArr[2]
+            vm.setTitle(MainTitle.Setting)
         }
 
         binding.bottomNavMain.setOnItemSelectedListener(this)
@@ -142,6 +137,14 @@ class MainActivity : AppCompatActivity(),
                 musicList.observe(this@MainActivity) { musicList ->
                     playerModel.replaceMusicList(musicList)
                 }
+
+                // Title과 UI 상태를 한번에 관찰
+                currentTitle.observe(this@MainActivity) { mainTitle ->
+                    binding.tvMainTitle.text = getString(mainTitle.resId)
+                    binding.ivBack.isVisible = mainTitle.showBackButton
+                    binding.ivSetting.isVisible = mainTitle.showSettingButton
+                    binding.ivSetting.isEnabled = mainTitle.showSettingButton
+                }
             }
         }
     }
@@ -151,22 +154,19 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
-        val titleArr = resources.getStringArray(R.array.title_array)
         val transaction = supportFragmentManager.beginTransaction()
         when (item.itemId) {
             R.id.menu_music_list -> {
                 val fragment = supportFragmentManager.findFragmentByTag("music_list")
                     ?: MusicListFragment.newInstance()
                 transaction.replace(binding.fcvMain.id, fragment, "music_list").commit()
-                binding.tvMainTitle.text = titleArr[0]
-                title = titleArr[0]
+                vm.setTitle(MainTitle.MusicList)
             }
             R.id.menu_my_play_list -> {
                 val fragment = supportFragmentManager.findFragmentByTag("my_play_list")
                     ?: MyPlaylistFragment.newInstance()
                 transaction.replace(binding.fcvMain.id, fragment, "my_play_list").commit()
-                binding.tvMainTitle.text = titleArr[1]
-                title = titleArr[1]
+                vm.setTitle(MainTitle.MyPlaylist)
             }
         }
         return true

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainViewModel.kt
@@ -1,9 +1,11 @@
 package com.hero.ziggymusic.view.main
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
+import com.hero.ziggymusic.view.main.model.MainTitle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -13,4 +15,12 @@ class MainViewModel @Inject constructor(
 ): ViewModel() {
 
     val musicList: LiveData<List<MusicModel>> = musicRepository.getAllMusic()
+
+    // MainTitle 상태 관리
+    private val _currentTitle = MutableLiveData<MainTitle>(MainTitle.MusicList)
+    val currentTitle: LiveData<MainTitle> = _currentTitle
+
+    fun setTitle(title: MainTitle) {
+        _currentTitle.value = title
+    }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainViewModel.kt
@@ -23,4 +23,8 @@ class MainViewModel @Inject constructor(
     fun setTitle(title: MainTitle) {
         _currentTitle.value = title
     }
+
+    fun navigateBack() {
+        _currentTitle.value = MainTitle.MusicList
+    }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/model/MainTitle.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/model/MainTitle.kt
@@ -1,0 +1,29 @@
+package com.hero.ziggymusic.view.main.model
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.hero.ziggymusic.R
+
+sealed class MainTitle(
+    @StringRes val resId: Int,
+    val showBackButton: Boolean = false,
+    val showSettingButton: Boolean = true,
+) {
+    object MusicList : MainTitle(R.string.title_music_list)
+    object MyPlaylist : MainTitle(R.string.title_my_playlist)
+    object Setting : MainTitle(
+        resId = R.string.title_setting,
+        showBackButton = true,
+        showSettingButton = false
+    )
+
+    companion object {
+        fun fromMenuId(menuId: Int): MainTitle? {
+            return when (menuId) {
+                R.id.menu_music_list -> MusicList
+                R.id.menu_my_play_list -> MyPlaylist
+                else -> null
+            }
+        }
+    }
+}

--- a/app/src/main/res/menu/menu_bt_nav.xml
+++ b/app/src/main/res/menu/menu_bt_nav.xml
@@ -6,7 +6,4 @@
     <item android:id="@+id/menu_my_play_list"
         android:title="@string/title_my_playlist"
         android:icon="@drawable/ic_my_play_list" />
-<!--    <item android:id="@+id/menu_setting"-->
-<!--        android:title="@string/title_setting"-->
-<!--        android:icon="@drawable/ic_setting" />-->
 </menu>


### PR DESCRIPTION
# PR 내용
- toolbarMain의 타이틀을 관리하는 로직 추가  
    - MainTitle sealed class 생성
    - MainViewModel에 setTitle 함수를 추가하여 타이틀 변경 기능 제공
    -  MainViewModel에 navigateBack 함수를 추가하여 설정 화면에서 메인 화면으로 이동할 때 toolBarMain의 타이틀의 visibility 관리
- BottomNavigation의 메뉴 항목에서 주석 처리된 setting 제거