### PR TITLE
[ Feature ] 마지막 재생 음원 및 재생 위치 로드 기능 추가

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/database/music/entity/MusicModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/music/entity/MusicModel.kt
@@ -7,10 +7,11 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
+import androidx.core.net.toUri
 
 @Parcelize
 @Entity(tableName = "music_table")
-data class MusicModel (
+data class MusicModel(
     @PrimaryKey
     val id: String,    // 음원 자체의 ID
     @ColumnInfo(name = "title")
@@ -24,7 +25,7 @@ data class MusicModel (
     @ColumnInfo(name = "duration")
     val duration: Long? = 0,     // 음원 재생 시간
     @ColumnInfo(name = "is_playing")
-    val isPlaying: Boolean = false
+    val isPlaying: Boolean = false,
 ) : Parcelable {
 
     fun getMusicFileUri(): Uri {
@@ -32,6 +33,6 @@ data class MusicModel (
     }
 
     fun getAlbumUri(): Uri {
-        return Uri.parse("content://media/external/audio/albumart/${albumId}")
+        return "content://media/external/audio/albumart/${albumId}".toUri()
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -43,6 +43,8 @@ import androidx.core.view.WindowInsetsControllerCompat
 import com.hero.ziggymusic.view.main.model.MainTitle
 import com.hero.ziggymusic.view.main.musiclist.MusicListFragment
 import com.hero.ziggymusic.view.main.myplaylist.MyPlaylistFragment
+import com.hero.ziggymusic.view.main.player.PlaybackContentType
+import com.hero.ziggymusic.view.main.player.PlaybackStateStore
 import com.hero.ziggymusic.view.main.player.PlayerMotionManager
 import com.hero.ziggymusic.view.main.player.viewmodel.PlayerViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -60,6 +62,7 @@ class MainActivity : AppCompatActivity(),
     lateinit var player: ExoPlayer
     private val playerModel: PlayerModel = PlayerModel.getInstance()
     private lateinit var playerController: PlayerController
+    private val playbackStateStore by lazy { PlaybackStateStore(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -290,7 +293,7 @@ class MainActivity : AppCompatActivity(),
             }
         }
         if (needs.isEmpty()) {
-            playerController.startPlayer()
+            playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
         } else {
             permissionLauncher.launch(needs.toTypedArray())
         }
@@ -321,7 +324,7 @@ class MainActivity : AppCompatActivity(),
         }
 
         // 오디오 권한 허용됨 -> 핵심 기능 시작
-        playerController.startPlayer()
+        playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
 
         // 알림 권한 선택적 처리
         if (!notifGranted) {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
@@ -15,7 +15,6 @@ class PlayerController(
     private val fragmentManager: FragmentManager,
     private val onStateChanged: (newState: Int) -> Unit
 ) : DefaultLifecycleObserver {
-
     private val bottomSheetBehavior: BottomSheetBehavior<View>
         get() = BottomSheetBehavior.from(fragmentContainer)
 
@@ -36,11 +35,11 @@ class PlayerController(
         lifecycleOwner.lifecycle.addObserver(this)
     }
 
-    fun startPlayer() {
+    fun startPlayer(initialMusicId: String = "") {
         fragmentManager.commit {
             add(
                 fragmentContainer.id,
-                PlayerFragment.newInstance(""),
+                PlayerFragment.newInstance(initialMusicId),
                 PlayerFragment.TAG
             )
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlaybackContentType.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlaybackContentType.kt
@@ -1,0 +1,23 @@
+package com.hero.ziggymusic.view.main.player
+
+enum class PlaybackContentType(
+    val idKey: String,
+    val positionKey: String,
+    val playWhenReadyKey: String
+) {
+    MUSIC(
+        idKey = "last_music_id",
+        positionKey = "last_music_position_ms",
+        playWhenReadyKey = "last_music_play_when_ready"
+    ),
+    RADIO(
+        idKey = "last_radio_id",
+        positionKey = "last_radio_position_ms",
+        playWhenReadyKey = "last_radio_play_when_ready"
+    ),
+    PODCAST(
+        idKey = "last_podcast_id",
+        positionKey = "last_podcast_position_ms",
+        playWhenReadyKey = "last_podcast_play_when_ready"
+    )
+}

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlaybackStateStore.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlaybackStateStore.kt
@@ -1,0 +1,80 @@
+package com.hero.ziggymusic.view.main.player
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hero.ziggymusic.view.main.player.model.LastPlayedMedia
+
+/**
+ * 마지막 재생 곡을 저장/복구하기 위한 간단한 영속 저장소
+ * (앱 프로세스가 종료되어도 유지)
+ */
+class PlaybackStateStore(context: Context) {
+    private val appContext: Context = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * 타입별 "마지막으로 재생한 ID"만 저장.
+     * (최소 저장이 필요할 때 사용)
+     */
+    fun saveLastPlayedId(type: PlaybackContentType, id: String) {
+        if (id.isBlank()) return
+        val now = System.currentTimeMillis()
+
+        prefs.edit {
+            putString(type.idKey, id)
+            putString(KEY_LAST_TYPE, type.name)
+            putLong(KEY_LAST_UPDATED_AT, now)
+        }
+    }
+
+    /**
+     * 앱 전체 기준 "마지막으로 재생한 항목" 저장.
+     * (type + id + position + playWhenReady)
+     */
+    fun saveLastPlayedMedia(media: LastPlayedMedia) {
+        val now = media.updatedAtMs.takeIf { it > 0L } ?: System.currentTimeMillis()
+
+        prefs.edit {
+            putString(media.type.idKey, media.id)
+            putLong(media.type.positionKey, media.positionMs)
+            putBoolean(media.type.playWhenReadyKey, media.playWhenReady)
+
+            putString(KEY_LAST_TYPE, media.type.name)
+            putLong(KEY_LAST_UPDATED_AT, now)
+        }
+    }
+
+    /**
+     * 앱 전체 기준 "마지막으로 재생된 콘텐츠 1개"를 복원
+     */
+    fun loadLastPlayedMedia(): LastPlayedMedia? {
+        val typeName = prefs.getString(KEY_LAST_TYPE, null) ?: return null
+        val type = runCatching { PlaybackContentType.valueOf(typeName) }.getOrNull()
+            ?: return null
+
+        val id = prefs.getString(type.idKey, null) ?: return null
+        val positionMs = prefs.getLong(type.positionKey, 0L)
+        val playWhenReady = prefs.getBoolean(type.playWhenReadyKey, false)
+        val updatedAtMs = prefs.getLong(KEY_LAST_UPDATED_AT, 0L).let { if (it > 0L) it else System.currentTimeMillis() }
+
+        return LastPlayedMedia(
+            type = type,
+            id = id,
+            positionMs = positionMs,
+            playWhenReady = playWhenReady,
+            updatedAtMs = updatedAtMs
+        )
+    }
+
+    /**
+     * 특정 타입(MUSIC/RADIO/PODCAST)에 대한 마지막 ID만 조회
+     */
+    fun loadLastPlayedId(type: PlaybackContentType): String? =
+        prefs.getString(type.idKey, null)
+
+    companion object {
+        private const val PREF_NAME = "ziggymusic_playback_prefs"
+        private const val KEY_LAST_TYPE = "last_playback_type"
+        private const val KEY_LAST_UPDATED_AT = "last_updated_at_ms"
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/model/LastPlayedMedia.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/model/LastPlayedMedia.kt
@@ -1,0 +1,25 @@
+package com.hero.ziggymusic.view.main.player.model
+
+import com.hero.ziggymusic.view.main.player.PlaybackContentType
+
+/**
+ * 앱 재실행 시 "직전에 들었던 항목"을 복원하기 위한 최소 상태 모델.
+ *
+ * - type + id: 어떤 종류의 무엇을 들었는지
+ * - positionMs: 팟캐스트/긴 트랙 재개에 필수 (라디오는 보통 0)
+ * - playWhenReady: 재실행 시 자동 재생 여부를 복원할지(정책에 따라 사용)
+ * - updatedAtMs: 가장 마지막으로 저장된 시각 (디버깅/정합성에 유용)
+ */
+data class LastPlayedMedia(
+    val type: PlaybackContentType,
+    val id: String,
+    val positionMs: Long = 0L,
+    val playWhenReady: Boolean = false,
+    val updatedAtMs: Long = System.currentTimeMillis()
+) {
+    init {
+        require(id.isNotBlank()) { "LastPlayedMedia.id must not be blank." }
+        require(positionMs >= 0L) { "LastPlayedMedia.positionMs must be >= 0." }
+        require(updatedAtMs > 0L) { "LastPlayedMedia.updatedAtMs must be > 0." }
+    }
+}


### PR DESCRIPTION
# PR 내용

## 변경 배경
- 앱 재실행 시 항상 1번 트랙이 로드되어 있는 문제 발생

## 주요 변경 사항
- LastPlayedMedia 모델 도입
    - 재생 콘텐츠 타입, id, 재생 위치, playWhenReady 상태를 함께 관리
- 앱 재실행 시 직전에 재생하던 음원과 재생 위치(positionMs)를 로드하도록 개선
- PlaybackStateStore를 통해 마지막 재생 상태를 저장
    - 재생 중/일시정지/백그라운드 진입 시점에 재생 위치를 저장하여 로드 정확도 향상
    - PlaybackContentType에 prefs key를 내장하여 타입별 저장/조회 구조 정리
    - 재생 위치 저장은 스로틀(주기 + 변화량 조건) 을 적용해 불필요한 prefs write 방지
- 앱 재실행 시 저장된 position을 기반으로 seekTo() 복원

## 기대 효과
- 앱 종료/재시작 후에도 사용자가 듣던 지점부터 자연스럽게 이어서 재생
- prefs write 빈도를 제한해 성능 및 배터리 영향 최소화
- 향후 팟캐스트/라디오 확장 시에도 재사용 가능한 구조 확보

## 참고 사항
- 재생 위치 저장은 PlayerFragment의 라이프사이클 및 Player 이벤트 기반으로 수행
- 기존 재생 로직과의 호환성을 유지하면서 점진적으로 확장 가능하도록 구성