### PR TITLE
[ Refactor ] Notification 앨범 아트 로드 로직 최적화

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -11,6 +11,7 @@ import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.widget.RemoteViews
@@ -174,38 +175,7 @@ class MusicService : MediaLibraryService() {
             }
 
             ACTION_REFRESH_NOTIFICATION, null -> {
-                currentAlbumArtBitmap = null
-                updateNotification()
-
-                val music = playerModel.currentMusic
-                val albumUri = music?.getAlbumUri()
-
-                albumArtLoadJob?.cancel()
-                albumArtLoadJob = serviceScope.launch {
-                    val bitmap = withContext(Dispatchers.IO) {
-                        try {
-                            if (albumUri == null) {
-                                null
-                            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                                val source = ImageDecoder.createSource(contentResolver, albumUri)
-                                ImageDecoder.decodeBitmap(source)
-                            } else {
-                                contentResolver.openInputStream(albumUri)?.use { input ->
-                                    BitmapFactory.decodeStream(input)
-                                }
-                            }
-                        } catch (e: Exception) {
-                            Log.e("MusicService", "album art decode failed", e)
-                            null
-                        }
-                    }
-
-                    if (isExiting) return@launch
-                    if (music?.getAlbumUri() != playerModel.currentMusic?.getAlbumUri()) return@launch
-
-                    currentAlbumArtBitmap = bitmap
-                    updateNotification()
-                }
+                refreshAlbumArt()
             }
         }
 
@@ -229,6 +199,99 @@ class MusicService : MediaLibraryService() {
         } else {
             startForeground(NOTIFICATION_ID, notification)
         }
+    }
+
+    private fun refreshAlbumArt() {
+        currentAlbumArtBitmap = null
+        updateNotification()
+
+        val expectedAlbumUri = playerModel.currentMusic?.getAlbumUri()
+
+        albumArtLoadJob?.cancel()
+        albumArtLoadJob = serviceScope.launch {
+            val bitmap = withContext(Dispatchers.IO) {
+                decodeAlbumArtForNotification(expectedAlbumUri)
+            }
+
+            if (isExiting) return@launch
+            if (expectedAlbumUri != playerModel.currentMusic?.getAlbumUri()) return@launch
+
+            currentAlbumArtBitmap = bitmap
+            updateNotification()
+        }
+    }
+
+    private fun decodeAlbumArtForNotification(albumUri: Uri?): Bitmap? {
+        if (albumUri == null) return null
+
+        return try {
+            val targetSizePx = 256
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val source = ImageDecoder.createSource(contentResolver, albumUri)
+                ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+                    val srcWidth = info.size.width
+                    val srcHeight = info.size.height
+
+                    val longestSide = maxOf(srcWidth, srcHeight)
+                    if (longestSide > targetSizePx) {
+                        val scale = targetSizePx.toFloat() / longestSide.toFloat()
+                        val targetWidth = (srcWidth * scale).toInt().coerceAtLeast(1)
+                        val targetHeight = (srcHeight * scale).toInt().coerceAtLeast(1)
+                        decoder.setTargetSize(targetWidth, targetHeight)
+                    }
+                }
+            } else {
+                val boundsOptions = BitmapFactory.Options().apply {
+                    inJustDecodeBounds = true
+                }
+
+                contentResolver.openInputStream(albumUri)?.use { input ->
+                    BitmapFactory.decodeStream(input, null, boundsOptions)
+                }
+
+                val sampleSize = calculateInSampleSize(
+                    width = boundsOptions.outWidth,
+                    height = boundsOptions.outHeight,
+                    reqWidth = targetSizePx,
+                    reqHeight = targetSizePx
+                )
+
+                val decodeOptions = BitmapFactory.Options().apply {
+                    inSampleSize = sampleSize
+                    inPreferredConfig = Bitmap.Config.RGB_565
+                }
+
+                contentResolver.openInputStream(albumUri)?.use { input ->
+                    BitmapFactory.decodeStream(input, null, decodeOptions)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("MusicService", "album art decode failed", e)
+            null
+        }
+    }
+
+    // 앨범 아트 크기 연산
+    private fun calculateInSampleSize(
+        width: Int,
+        height: Int,
+        reqWidth: Int,
+        reqHeight: Int
+    ): Int {
+        if (width <= 0 || height <= 0) return 1
+
+        var inSampleSize = 1
+        val halfWidth = width / 2
+        val halfHeight = height / 2
+
+        while ((halfWidth / inSampleSize) >= reqWidth &&
+            (halfHeight / inSampleSize) >= reqHeight
+        ) {
+            inSampleSize *= 2
+        }
+
+        return inSampleSize.coerceAtLeast(1)
     }
 
     private fun updateNotification() {


### PR DESCRIPTION
# PR 내용

- 앨범아트 비동기 로딩 로직을 refreshAlbumArt()로 통합하여 중복 코드 제거
- onMediaItemTransition()과 ACTION_REFRESH_NOTIFICATION에서 동일한 로딩 경로를 사용하도록 구조 개선
- 앨범아트 디코딩 로직을 decodeAlbumArtForNotification()로 분리하여 책임을 명확히 분리
- Notification 용도에 맞게 이미지 크기를 제한하도록 다운샘플링 로직 적용 (ImageDecoder / BitmapFactory 공통 적용)
- Android P 이상에서는 ImageDecoder.setTargetSize()를 활용한 스케일링 적용,
   Android P 미만에서는 inSampleSize 기반 다운샘플링을 적용하여 메모리 사용량 최적화
- 디코딩 시 RGB_565 포맷을 사용하여 메모리 사용량 감소
- 앨범아트 로딩 전 기존 Job을 cancel하도록 하여 불필요한 작업 중복 방지
- 현재 재생 곡과 다른 앨범아트 결과가 반영되지 않도록 URI 비교 로직 유지 및 안정성 강화
- 앨범아트 로딩 실패 시 예외 처리 일원화 및 로그 처리 통합
- Notification 갱신 흐름을 로딩 시작/완료 시점으로 명확히 분리하여 UI 반응성 개선

# 기대효과
- 앨범아트 처리 경로를 단일화하여 유지보수성과 확장성 향상
- 앨범 아트 로드 부하가 적어져서 비정상 종료 가능성 낮아짐