### PR TITLE
[ Refactor ] AudioEffectManager 구조 개선 및 Vertical SeekBar 커스텀 View 분리

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -29,7 +29,7 @@ import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.ActivityMainBinding
 import com.hero.ziggymusic.event.Event
 import com.hero.ziggymusic.event.EventBus
-import com.hero.ziggymusic.view.main.setting.SoundEQSettings
+import com.hero.ziggymusic.view.main.setting.AudioEffectManager
 import com.hero.ziggymusic.view.main.setting.SettingFragment
 import com.squareup.otto.Subscribe
 import dagger.hilt.android.AndroidEntryPoint
@@ -468,12 +468,12 @@ class MainActivity : AppCompatActivity(),
     @OptIn(UnstableApi::class)
     private fun initSoundEQSettings() {
         if (player.audioSessionId != 0) {
-            SoundEQSettings.init(player.audioSessionId)
+            AudioEffectManager.init(player.audioSessionId)
         } else {
             player.addListener(object : Player.Listener {
                 override fun onAudioSessionIdChanged(audioSessionId: Int) {
                     if (audioSessionId != 0) {
-                        SoundEQSettings.init(audioSessionId)
+                        AudioEffectManager.init(audioSessionId)
                         player.removeListener(this)
                     }
                 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/setting/AudioEffectManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/setting/AudioEffectManager.kt
@@ -13,7 +13,7 @@ import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_HEAD_
 import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_SPATIAL_ENABLED
 import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_VIRTUALIZER
 
-object SoundEQSettings {
+object AudioEffectManager {
     var equalizer: Equalizer? = null
         private set
     var bassBoost: BassBoost? = null

--- a/app/src/main/java/com/hero/ziggymusic/view/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/setting/SettingFragment.kt
@@ -2,10 +2,6 @@ package com.hero.ziggymusic.view.main.setting
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.media.audiofx.BassBoost
-import android.media.audiofx.Equalizer
-import android.media.audiofx.PresetReverb
-import android.media.audiofx.Virtualizer
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -24,10 +20,11 @@ import androidx.fragment.app.Fragment
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.databinding.FragmentSettingBinding
 import androidx.core.content.edit
-import androidx.core.graphics.toColorInt
 import com.hero.ziggymusic.audio.HeadTracker
 import com.hero.ziggymusic.audio.PlayerAudioGraph
 import com.hero.ziggymusic.audio.SpatializerSupport
+import com.hero.ziggymusic.view.main.setting.SoundEQSettings.equalizer
+import com.hero.ziggymusic.view.main.setting.SoundEQSettings.mainColor
 
 class SettingFragment : Fragment() {
     private var _binding: FragmentSettingBinding? = null
@@ -62,7 +59,6 @@ class SettingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         initSetting()
-        initializeAudioEngine()
 
         initEqualizer()
         initBassSeekBar(prefs)
@@ -71,31 +67,19 @@ class SettingFragment : Fragment() {
         initSpatialAudioUi() // XR 기능 UI 설정
     }
 
-    private fun initializeAudioEngine() {
-        runCatching {
-            val spatialEnabled = prefs.getBoolean(KEY_SPATIAL_ENABLED, false)
-            val headEnabled = prefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, false)
-            SoundEQSettings.setSpatialEnabled(spatialEnabled)
-            SoundEQSettings.setHeadTrackingEnabled(spatialEnabled && headEnabled)
-        }
-    }
-
     // Spatial Audio & Head Tracking UI 설정
     private fun initSpatialAudioUi() {
         Log.d("SettingFragment", "Spatializer status: ${spatializerSupport.describeStatus()}")
+
+        binding.swSpatialAudio.setOnCheckedChangeListener(null)
+        binding.swHeadTracking.setOnCheckedChangeListener(null)
+
         // 1. Spatial Audio & Head Tracking Enable Switch
         val spatialEnabled = prefs.getBoolean(KEY_SPATIAL_ENABLED, false)
         val headEnabled = prefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, false)
 
-        binding.swSpatialAudio.setOnCheckedChangeListener(null)
-        binding.swHeadTracking.setOnCheckedChangeListener(null)
         binding.swSpatialAudio.isChecked = spatialEnabled
-        binding.swHeadTracking.isChecked = headEnabled && spatialEnabled
-
-        headTracker.setOnHeadPoseListener { yawDeg ->
-            // JNI Controller로 센서값 주입
-            PlayerAudioGraph.setHeadTrackingActive(spatialEnabled, headEnabled)
-        }
+        binding.swHeadTracking.isChecked = spatialEnabled && headEnabled
 
         updateHeadTrackingUiState(spatialEnabled)
 
@@ -103,18 +87,41 @@ class SettingFragment : Fragment() {
         runCatching {
             SoundEQSettings.setSpatialEnabled(spatialEnabled)
             SoundEQSettings.setHeadTrackingEnabled(spatialEnabled && headEnabled)
+
+            if (spatialEnabled && headEnabled) {
+                PlayerAudioGraph.setHeadTrackingActive(true, true)
+                headTracker.start()
+            } else {
+                PlayerAudioGraph.setHeadTrackingActive(false, false)
+                headTracker.stop()
+            }
+        }
+
+        headTracker.setOnHeadPoseListener { yawDeg ->
+            val isSpatialOn = binding.swSpatialAudio.isChecked
+            val isHeadTrackingOn = binding.swHeadTracking.isChecked
+
+            if (isSpatialOn && isHeadTrackingOn) {
+                SoundEQSettings.setHeadTrackingYaw(yawDeg)
+            }
         }
 
         // 3. head switch는 한 번만 설정
         binding.swHeadTracking.setOnCheckedChangeListener { _, isChecked ->
             prefs.edit { putBoolean(KEY_HEAD_TRACKING_ENABLED, isChecked) }
 
-            if (isChecked && binding.swSpatialAudio.isChecked) {
+            val isSpatialOn = binding.swSpatialAudio.isChecked
+            val shouldTrack = isSpatialOn && isChecked
+
+            SoundEQSettings.setHeadTrackingEnabled(shouldTrack)
+
+            // JNI Controller로 센서값 주입
+            PlayerAudioGraph.setHeadTrackingActive(shouldTrack, shouldTrack)
+
+            if (shouldTrack) {
                 headTracker.start()
-                SoundEQSettings.setHeadTrackingEnabled(true)
             } else {
                 headTracker.stop()
-                SoundEQSettings.setHeadTrackingEnabled(false)
             }
         }
 
@@ -130,15 +137,20 @@ class SettingFragment : Fragment() {
             if (!isChecked) {
                 // spatial off -> 강제 head off, 리스너는 유지(한 번만 설정)
                 binding.swHeadTracking.isChecked = false
-                binding.swHeadTracking.isEnabled = false
-                headTracker.stop()
                 SoundEQSettings.setHeadTrackingEnabled(false)
+                PlayerAudioGraph.setHeadTrackingActive(
+                    spatialEnabled = false,
+                    headTrackingEnabled = false
+                )
+                headTracker.stop()
             } else {
                 // spatial on: 기존 head 상태가 on이면 시작, head 스위치는 활성화
-                binding.swHeadTracking.isEnabled = true
-                if (binding.swHeadTracking.isChecked) {
+                val shouldTrack = binding.swHeadTracking.isChecked
+                SoundEQSettings.setHeadTrackingEnabled(shouldTrack)
+                PlayerAudioGraph.setHeadTrackingActive(shouldTrack, shouldTrack)
+
+                if (shouldTrack) {
                     headTracker.start()
-                    SoundEQSettings.setHeadTrackingEnabled(true)
                 }
             }
 
@@ -162,38 +174,18 @@ class SettingFragment : Fragment() {
 
     private fun initSetting() {
         prefs = requireContext().getSharedPreferences("SettingFragment", 0)
-
-        // SettingFragment 진입 시점에 재생 중인 오디오 세션을 건드리지 않도록 "자동 enabled" 금지
-        // (필요하면 사용자가 스위치/슬라이더 조작할 때만 enabled 변경)
-        val enabled = prefs.getBoolean("ENABLED", false)
-
-        equalizer?.enabled = enabled
-        reverb?.enabled = enabled && (prefs.getInt("REVERB", 0) != 0)
-
-        // Bass/Virtualizer는 progress==0이면 반드시 OFF (기기별 잡음/파이프라인 변경 방지)
-        val bassProgress = prefs.getInt("BASS", 0)
-        bassBoost?.enabled = enabled && bassProgress > 0
-
-        val virtualizerProgress = prefs.getInt("VIRTUALIZER", 0)
-        virtualizer?.enabled = enabled && virtualizerProgress > 0
-
+        SoundEQSettings.setEnabledFromPrefs(prefs)
     }
 
     private fun initPresets(min: Int) {
-        if (equalizer == null) {
-            // 실제 오디오 출력 또는 프리뷰 세션 ID가 있으면 전달.
-            // 기본은 0(전역)으로 유지하되, 외부에서 세션이 확보되면 attachAudioSession을 호출해 재초기화 가능.
-            val sessionId = 0
-            equalizer = Equalizer(0, sessionId)
-        }
-
-        val noOfPresets = equalizer!!.numberOfPresets
+        val noOfPresets = SoundEQSettings.getNumberOfPresets()
+        if (noOfPresets <= 0) return
 
         val presets = arrayOfNulls<String>(noOfPresets + 1)
         presets[0] = "Custom"
 
         for (i in 0 until noOfPresets) {
-            presets[i + 1] = equalizer!!.getPresetName(i.toShort())
+            presets[i + 1] = SoundEQSettings.getPresetName(i)
         }
 
         val spinnerAdapter: ArrayAdapter<String?> = ArrayAdapter(
@@ -201,8 +193,8 @@ class SettingFragment : Fragment() {
             R.layout.item_spinner,
             presets
         )
-        binding.spinnerPreset.adapter = spinnerAdapter
 
+        binding.spinnerPreset.adapter = spinnerAdapter
         binding.spinnerPreset.setSelection(prefs.getInt("PRESET", 1))
 
         binding.spinnerPreset.onItemSelectedListener =
@@ -216,127 +208,131 @@ class SettingFragment : Fragment() {
                     if (equalizer != null) {
                         prefs.edit { putInt("PRESET", position) }
 
-                        Runnable {
-                            if (position != 0) {
-                                equalizer!!.usePreset((position - 1).toShort())
-                                for (i in seekbarIds.indices) {
-                                    Runnable {
-                                        val seekbar =
-                                            requireActivity().findViewById<SoundEQVerticalSeekbar>(seekbarIds[i])
-                                        seekbar.shouldChange = false
-                                        seekbar.progress = 1
-                                        seekbar.progress =
-                                            equalizer!!.getBandLevel(i.toShort()) - min
-                                        seekbar.updateThumb()
-                                    }.run()
-                                }
+                        if (position != 0) {
+                            SoundEQSettings.useEqualizerPreset(position - 1)
+
+                            for (i in seekbarIds.indices) {
+                                val seekbar =
+                                    requireActivity().findViewById<SoundEQVerticalSeekbar>(seekbarIds[i])
+                                seekbar.shouldChange = false
+                                seekbar.progress = 1
+                                seekbar.progress =
+                                    (SoundEQSettings.getBandLevel(i)?.toInt() ?: 0) - min
+                                seekbar.updateThumb()
                             }
-                        }.run()
+                        }
                     }
                 }
 
-                override fun onNothingSelected(parent: AdapterView<*>?) {}
+                override fun onNothingSelected(parent: AdapterView<*>?) = Unit
             }
     }
 
     private fun initEqualizer() {
-        if (equalizer != null) {
-            val max = equalizer!!.bandLevelRange[1].toInt()
-            val min = equalizer!!.bandLevelRange[0].toInt()
-            var uiMaxForNative = 0
+        val equalizer = SoundEQSettings.equalizer ?: return
+        val bandLevelRange = SoundEQSettings.getBandLevelRange() ?: return
+        val max = bandLevelRange[1].toInt()
+        val min = bandLevelRange[0].toInt()
+        var uiMaxForNative = 0
 
-            for (index in 0 until equalizer!!.numberOfBands) {
-                val verticalSeekbar =
-                    SoundEQVerticalSeekbar(requireContext())
-                seekbarIds.add(index, View.generateViewId())
-                verticalSeekbar.max = max - min
-                verticalSeekbar.tag = index
-                uiMaxForNative = verticalSeekbar.max
+        seekbarIds.clear()
+        binding.tvSeekbar.removeAllViews()
+        binding.seekbarContainer.removeAllViews()
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    verticalSeekbar.maxHeight = 1
-                }
-                verticalSeekbar.id = seekbarIds[index]
-                verticalSeekbar.splitTrack = true
+        val numberOfBands = SoundEQSettings.getNumberOfBands()
 
-                verticalSeekbar.progressDrawable.setTint(mainColor)
-                verticalSeekbar.thumb.setTint(mainColor)
+        for (index in 0 until numberOfBands) {
+            val verticalSeekbar = SoundEQVerticalSeekbar(requireContext())
+            seekbarIds.add(index, View.generateViewId())
+            verticalSeekbar.max = max - min
+            verticalSeekbar.tag = index
+            uiMaxForNative = verticalSeekbar.max
 
-                verticalSeekbar.progress = prefs.getInt(
-                    index.toString(),
-                    equalizer!!.getBandLevel(index.toShort()).toInt() - min
-                )
-
-                verticalSeekbar.setOnSeekBarChangeListener(object :
-                    SeekBar.OnSeekBarChangeListener {
-                    override fun onProgressChanged(
-                        seekBar: SeekBar,
-                        progress: Int,
-                        fromUser: Boolean,
-                    ) {
-                        if (equalizer != null) {
-                            if (verticalSeekbar.shouldChange) {
-                                binding.spinnerPreset.setSelection(0)
-                                prefs.edit { putInt(seekBar.tag.toString(), progress) }
-
-                                if (equalizer!!.enabled) {
-                                    equalizer!!.setBandLevel(
-                                        (seekBar.tag as Int).toShort(),
-                                        (progress + min).toShort()
-                                    )
-                                }
-
-                                // 네이티브 EQ에도 동일 변경 반영
-                                val bandIndex = (seekBar.tag as Int)
-                                val gainDb = mapEqProgressToDb(
-                                    progress = progress,
-                                    max = seekBar.max
-                                )
-                                SoundEQSettings.setBandGain(bandIndex, gainDb)
-                            }
-                        }
-                    }
-
-                    override fun onStartTrackingTouch(seekBar: SeekBar) {}
-                    override fun onStopTrackingTouch(seekBar: SeekBar) {}
-                })
-
-                val layoutParams: TableRow.LayoutParams =
-                    TableRow.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.0f)
-                verticalSeekbar.layoutParams = layoutParams
-
-                var title: String
-                if (equalizer!!.getCenterFreq(index.toShort()) > 1000000) {
-                    title = "${equalizer!!.getCenterFreq(index.toShort()) / 1000000} kHz"
-                } else {
-                    title = "${equalizer!!.getCenterFreq(index.toShort()) / 1000} "
-                    title = title.substring(0, title.length - 2) + " Hz"
-                }
-
-                val textView = TextView(requireContext())
-                textView.text = title
-                textView.maxLines = 1
-                textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, resources.getDimension(R.dimen.small_text_size))
-                textView.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
-
-                val params: TableRow.LayoutParams =
-                    TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
-                textView.gravity = Gravity.CENTER
-                textView.layoutParams = params
-                binding.tvSeekbar.addView(textView)
-                binding.seekbarContainer.addView(verticalSeekbar)
-
-                // 초기 로딩 시 네이티브 밴드도 저장값으로 동기화
-                val initialGainDb = mapEqProgressToDb(
-                    progress = verticalSeekbar.progress,
-                    max = verticalSeekbar.max
-                )
-                SoundEQSettings.setBandGain(index, initialGainDb)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                verticalSeekbar.maxHeight = 1
             }
 
-            runCatching { SoundEQSettings.applySettingsFromPrefs(prefs, eqMaxFromUi = uiMaxForNative) }
-            initPresets(min)
+            verticalSeekbar.id = seekbarIds[index]
+            verticalSeekbar.splitTrack = true
+
+            verticalSeekbar.progressDrawable.setTint(mainColor)
+            verticalSeekbar.thumb.setTint(mainColor)
+
+            verticalSeekbar.progress = prefs.getInt(
+                index.toString(),
+                (SoundEQSettings.getBandLevel(index)?.toInt() ?: 0) - min
+            )
+
+            verticalSeekbar.setOnSeekBarChangeListener(object :
+                SeekBar.OnSeekBarChangeListener { override fun onProgressChanged(
+                seekBar: SeekBar,
+                progress: Int,
+                fromUser: Boolean,
+                ) {
+                    if (!verticalSeekbar.shouldChange) return
+
+                    binding.spinnerPreset.setSelection(0)
+                    prefs.edit { putInt(seekBar.tag.toString(), progress) }
+
+                    if (SoundEQSettings.equalizer?.enabled == true) {
+                        SoundEQSettings.applyEqualizerBandLevel(
+                            bandIndex = seekBar.tag as Int,
+                            level = (progress + min).toShort()
+                        )
+                    }
+
+                    val bandIndex = seekBar.tag as Int
+                    val gainDb = mapEqProgressToDb(
+                        progress = progress,
+                        max = seekBar.max
+                    )
+                    SoundEQSettings.setBandGain(bandIndex, gainDb)
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+                override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
+            })
+
+            val layoutParams: TableRow.LayoutParams =
+                TableRow.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.0f)
+            verticalSeekbar.layoutParams = layoutParams
+
+            val centerFreq = SoundEQSettings.getCenterFreq(index) ?: 0
+            val title = if (centerFreq > 1000000) {
+                "${centerFreq / 1000000} kHz"
+            } else {
+                "${centerFreq / 1000} ".let { it.substring(0, it.length - 2) + " Hz" }
+            }
+
+            val textView = TextView(requireContext())
+            textView.text = title
+            textView.maxLines = 1
+            textView.setTextSize(
+                TypedValue.COMPLEX_UNIT_PX,
+                resources.getDimension(R.dimen.small_text_size)
+            )
+            textView.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+
+            val params =
+                TableRow.LayoutParams(0, TableRow.LayoutParams.WRAP_CONTENT, 1f)
+            textView.gravity = Gravity.CENTER
+            textView.layoutParams = params
+
+            binding.tvSeekbar.addView(textView)
+            binding.seekbarContainer.addView(verticalSeekbar)
+
+            val initialGainDb = mapEqProgressToDb(
+                progress = verticalSeekbar.progress,
+                max = verticalSeekbar.max
+            )
+            SoundEQSettings.setBandGain(index, initialGainDb)
         }
+
+        runCatching {
+            SoundEQSettings.applySettingsFromPrefs(prefs, eqMaxFromUi = uiMaxForNative)
+        }
+
+        initPresets(min)
     }
 
     // SettingsFragment의 progress 범위를 기준으로 dB로 환산
@@ -347,7 +343,8 @@ class SettingFragment : Fragment() {
     }
 
     private fun initReverb() {
-        val reverbAdapter = ArrayAdapter(requireContext(),
+        val reverbAdapter = ArrayAdapter(
+            requireContext(),
             R.layout.item_spinner,
             arrayOf(
             "None",
@@ -369,88 +366,58 @@ class SettingFragment : Fragment() {
                 position: Int,
                 id: Long,
             ) {
-                if (reverb != null) {
-                    Runnable {
-                        reverb!!.preset = position.toShort()
-                        reverb!!.enabled = true
-                        prefs.edit { putInt("REVERB", position) }
-                    }.run()
+                if (SoundEQSettings.reverb != null) {
+                    SoundEQSettings.applyReverbPreset(position, prefs)
                 }
             }
 
-            override fun onNothingSelected(parent: AdapterView<*>?) {}
+            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
         }
     }
 
     private fun initBassSeekBar(settings: SharedPreferences) {
         val bassProgress = settings.getInt("BASS", 0)
 
-        if (bassBoost != null) {
-            if (bassBoost!!.strengthSupported) {
-                bassBoost!!.setStrength((bassProgress * 15).toShort())
-                bassBoost!!.enabled = true
-            }
-        }
+        SoundEQSettings.applyBassStrength(bassProgress)
 
-        binding.sbBass.progressDrawable.setTint(mainColor)
-        binding.sbBass.thumb.setTint(mainColor)
+        binding.sbBass.progressDrawable.setTint(SoundEQSettings.mainColor)
+        binding.sbBass.thumb.setTint(SoundEQSettings.mainColor)
         binding.sbBass.progress = bassProgress
 
         binding.sbBass.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                if (bassBoost != null) {
-                    if (bassBoost!!.strengthSupported) {
-                        bassBoost!!.setStrength(((progress * 15).toShort()))
-                        bassBoost!!.enabled = true
-                    }
-                }
+                SoundEQSettings.applyBassStrength(progress, prefs)
             }
 
-            override fun onStartTrackingTouch(seekBar: SeekBar) {}
-            override fun onStopTrackingTouch(seekBar: SeekBar) {}
+            override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+            override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
         })
     }
 
     private fun initVirtualizerSeekbar() {
         val virtualizerProgress = prefs.getInt("VIRTUALIZER", 0)
 
-        if (virtualizer != null) {
-            if (virtualizer!!.strengthSupported) {
-                virtualizer!!.setStrength((virtualizerProgress * 15).toShort())
-                virtualizer!!.enabled = true
-            }
-        }
+        SoundEQSettings.applyVirtualizerStrength(virtualizerProgress)
 
-        binding.sbVirtualizer.progressDrawable.setTint(mainColor)
-        binding.sbVirtualizer.thumb.setTint(mainColor)
+        binding.sbVirtualizer.progressDrawable.setTint(SoundEQSettings.mainColor)
+        binding.sbVirtualizer.thumb.setTint(SoundEQSettings.mainColor)
         binding.sbVirtualizer.progress = virtualizerProgress
 
-        binding.sbVirtualizer.setOnSeekBarChangeListener(object :
-            SeekBar.OnSeekBarChangeListener {
+        binding.sbVirtualizer.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                if (virtualizer != null) {
-                    if (virtualizer!!.strengthSupported) {
-                        virtualizer!!.setStrength((progress * 15).toShort())
-                        virtualizer!!.enabled = true
-                    }
-                }
+                SoundEQSettings.applyVirtualizerStrength(progress, prefs)
             }
 
-            override fun onStartTrackingTouch(seekBar: SeekBar) {}
-            override fun onStopTrackingTouch(seekBar: SeekBar) {}
+            override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+            override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
         })
     }
 
     override fun onResume() {
         super.onResume()
 
-        val settings = requireContext().getSharedPreferences("SettingFragment", 0)
-
-        val virtualizerProgress = settings.getInt("VIRTUALIZER", 0)
-        binding.sbVirtualizer.progress = virtualizerProgress
-
-        val bassProgress = settings!!.getInt("BASS", 0)
-        binding.sbBass.progress = bassProgress
+        binding.sbVirtualizer.progress = prefs.getInt(KEY_VIRTUALIZER, 0)
+        binding.sbBass.progress = prefs.getInt(KEY_BASS, 0)
 
         // 화면에 돌아왔을 때 설정에 따라 트래킹 재개
         if (binding.swSpatialAudio.isChecked && binding.swHeadTracking.isChecked) {
@@ -460,11 +427,6 @@ class SettingFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-
-        requireContext().getSharedPreferences("SettingFragment", 0).edit {
-            putInt("BASS", binding.sbBass.progress)
-            putInt("VIRTUALIZER", binding.sbVirtualizer.progress)
-        }
 
         // Preference 저장 로직
         prefs.edit {
@@ -486,11 +448,5 @@ class SettingFragment : Fragment() {
         const val KEY_HEAD_TRACKING_ENABLED = "HEAD_TRACKING_ENABLED"
         const val KEY_BASS = "BASS"
         const val KEY_VIRTUALIZER = "VIRTUALIZER"
-
-        var equalizer: Equalizer? = null
-        var reverb: PresetReverb? = null
-        var bassBoost: BassBoost? = null
-        var virtualizer: Virtualizer? = null
-        var mainColor = "#00ffee".toColorInt()
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/setting/SettingFragment.kt
@@ -23,8 +23,8 @@ import androidx.core.content.edit
 import com.hero.ziggymusic.audio.HeadTracker
 import com.hero.ziggymusic.audio.PlayerAudioGraph
 import com.hero.ziggymusic.audio.SpatializerSupport
-import com.hero.ziggymusic.view.main.setting.SoundEQSettings.equalizer
-import com.hero.ziggymusic.view.main.setting.SoundEQSettings.mainColor
+import com.hero.ziggymusic.view.main.setting.AudioEffectManager.equalizer
+import com.hero.ziggymusic.view.main.setting.AudioEffectManager.mainColor
 
 class SettingFragment : Fragment() {
     private var _binding: FragmentSettingBinding? = null
@@ -85,8 +85,8 @@ class SettingFragment : Fragment() {
 
         // 2. 초기 적용: 네이티브에 현재 prefs 반영
         runCatching {
-            SoundEQSettings.setSpatialEnabled(spatialEnabled)
-            SoundEQSettings.setHeadTrackingEnabled(spatialEnabled && headEnabled)
+            AudioEffectManager.setSpatialEnabled(spatialEnabled)
+            AudioEffectManager.setHeadTrackingEnabled(spatialEnabled && headEnabled)
 
             if (spatialEnabled && headEnabled) {
                 PlayerAudioGraph.setHeadTrackingActive(true, true)
@@ -102,7 +102,7 @@ class SettingFragment : Fragment() {
             val isHeadTrackingOn = binding.swHeadTracking.isChecked
 
             if (isSpatialOn && isHeadTrackingOn) {
-                SoundEQSettings.setHeadTrackingYaw(yawDeg)
+                AudioEffectManager.setHeadTrackingYaw(yawDeg)
             }
         }
 
@@ -113,7 +113,7 @@ class SettingFragment : Fragment() {
             val isSpatialOn = binding.swSpatialAudio.isChecked
             val shouldTrack = isSpatialOn && isChecked
 
-            SoundEQSettings.setHeadTrackingEnabled(shouldTrack)
+            AudioEffectManager.setHeadTrackingEnabled(shouldTrack)
 
             // JNI Controller로 센서값 주입
             PlayerAudioGraph.setHeadTrackingActive(shouldTrack, shouldTrack)
@@ -132,12 +132,12 @@ class SettingFragment : Fragment() {
                 if (!isChecked) putBoolean(KEY_HEAD_TRACKING_ENABLED, false)
             }
 
-            SoundEQSettings.setSpatialEnabled(isChecked)
+            AudioEffectManager.setSpatialEnabled(isChecked)
 
             if (!isChecked) {
                 // spatial off -> 강제 head off, 리스너는 유지(한 번만 설정)
                 binding.swHeadTracking.isChecked = false
-                SoundEQSettings.setHeadTrackingEnabled(false)
+                AudioEffectManager.setHeadTrackingEnabled(false)
                 PlayerAudioGraph.setHeadTrackingActive(
                     spatialEnabled = false,
                     headTrackingEnabled = false
@@ -146,7 +146,7 @@ class SettingFragment : Fragment() {
             } else {
                 // spatial on: 기존 head 상태가 on이면 시작, head 스위치는 활성화
                 val shouldTrack = binding.swHeadTracking.isChecked
-                SoundEQSettings.setHeadTrackingEnabled(shouldTrack)
+                AudioEffectManager.setHeadTrackingEnabled(shouldTrack)
                 PlayerAudioGraph.setHeadTrackingActive(shouldTrack, shouldTrack)
 
                 if (shouldTrack) {
@@ -174,18 +174,18 @@ class SettingFragment : Fragment() {
 
     private fun initSetting() {
         prefs = requireContext().getSharedPreferences("SettingFragment", 0)
-        SoundEQSettings.setEnabledFromPrefs(prefs)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
     }
 
     private fun initPresets(min: Int) {
-        val noOfPresets = SoundEQSettings.getNumberOfPresets()
+        val noOfPresets = AudioEffectManager.getNumberOfPresets()
         if (noOfPresets <= 0) return
 
         val presets = arrayOfNulls<String>(noOfPresets + 1)
         presets[0] = "Custom"
 
         for (i in 0 until noOfPresets) {
-            presets[i + 1] = SoundEQSettings.getPresetName(i)
+            presets[i + 1] = AudioEffectManager.getPresetName(i)
         }
 
         val spinnerAdapter: ArrayAdapter<String?> = ArrayAdapter(
@@ -209,16 +209,15 @@ class SettingFragment : Fragment() {
                         prefs.edit { putInt("PRESET", position) }
 
                         if (position != 0) {
-                            SoundEQSettings.useEqualizerPreset(position - 1)
+                            AudioEffectManager.useEqualizerPreset(position - 1)
 
                             for (i in seekbarIds.indices) {
                                 val seekbar =
                                     requireActivity().findViewById<SoundEQVerticalSeekbar>(seekbarIds[i])
-                                seekbar.shouldChange = false
                                 seekbar.progress = 1
                                 seekbar.progress =
-                                    (SoundEQSettings.getBandLevel(i)?.toInt() ?: 0) - min
-                                seekbar.updateThumb()
+                                    (AudioEffectManager.getBandLevel(i)?.toInt() ?: 0) - min
+                                seekbar.refreshThumbState()
                             }
                         }
                     }
@@ -229,8 +228,8 @@ class SettingFragment : Fragment() {
     }
 
     private fun initEqualizer() {
-        val equalizer = SoundEQSettings.equalizer ?: return
-        val bandLevelRange = SoundEQSettings.getBandLevelRange() ?: return
+        val equalizer = AudioEffectManager.equalizer ?: return
+        val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
         val max = bandLevelRange[1].toInt()
         val min = bandLevelRange[0].toInt()
         var uiMaxForNative = 0
@@ -239,7 +238,7 @@ class SettingFragment : Fragment() {
         binding.tvSeekbar.removeAllViews()
         binding.seekbarContainer.removeAllViews()
 
-        val numberOfBands = SoundEQSettings.getNumberOfBands()
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
 
         for (index in 0 until numberOfBands) {
             val verticalSeekbar = SoundEQVerticalSeekbar(requireContext())
@@ -260,7 +259,7 @@ class SettingFragment : Fragment() {
 
             verticalSeekbar.progress = prefs.getInt(
                 index.toString(),
-                (SoundEQSettings.getBandLevel(index)?.toInt() ?: 0) - min
+                (AudioEffectManager.getBandLevel(index)?.toInt() ?: 0) - min
             )
 
             verticalSeekbar.setOnSeekBarChangeListener(object :
@@ -269,13 +268,13 @@ class SettingFragment : Fragment() {
                 progress: Int,
                 fromUser: Boolean,
                 ) {
-                    if (!verticalSeekbar.shouldChange) return
+                    if (!verticalSeekbar.isTrackingTouch) return
 
                     binding.spinnerPreset.setSelection(0)
                     prefs.edit { putInt(seekBar.tag.toString(), progress) }
 
-                    if (SoundEQSettings.equalizer?.enabled == true) {
-                        SoundEQSettings.applyEqualizerBandLevel(
+                    if (AudioEffectManager.equalizer?.enabled == true) {
+                        AudioEffectManager.applyEqualizerBandLevel(
                             bandIndex = seekBar.tag as Int,
                             level = (progress + min).toShort()
                         )
@@ -286,7 +285,7 @@ class SettingFragment : Fragment() {
                         progress = progress,
                         max = seekBar.max
                     )
-                    SoundEQSettings.setBandGain(bandIndex, gainDb)
+                    AudioEffectManager.setBandGain(bandIndex, gainDb)
                 }
 
                 override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
@@ -297,7 +296,7 @@ class SettingFragment : Fragment() {
                 TableRow.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.0f)
             verticalSeekbar.layoutParams = layoutParams
 
-            val centerFreq = SoundEQSettings.getCenterFreq(index) ?: 0
+            val centerFreq = AudioEffectManager.getCenterFreq(index) ?: 0
             val title = if (centerFreq > 1000000) {
                 "${centerFreq / 1000000} kHz"
             } else {
@@ -325,11 +324,11 @@ class SettingFragment : Fragment() {
                 progress = verticalSeekbar.progress,
                 max = verticalSeekbar.max
             )
-            SoundEQSettings.setBandGain(index, initialGainDb)
+            AudioEffectManager.setBandGain(index, initialGainDb)
         }
 
         runCatching {
-            SoundEQSettings.applySettingsFromPrefs(prefs, eqMaxFromUi = uiMaxForNative)
+            AudioEffectManager.applySettingsFromPrefs(prefs, eqMaxFromUi = uiMaxForNative)
         }
 
         initPresets(min)
@@ -366,8 +365,8 @@ class SettingFragment : Fragment() {
                 position: Int,
                 id: Long,
             ) {
-                if (SoundEQSettings.reverb != null) {
-                    SoundEQSettings.applyReverbPreset(position, prefs)
+                if (AudioEffectManager.reverb != null) {
+                    AudioEffectManager.applyReverbPreset(position, prefs)
                 }
             }
 
@@ -378,15 +377,15 @@ class SettingFragment : Fragment() {
     private fun initBassSeekBar(settings: SharedPreferences) {
         val bassProgress = settings.getInt("BASS", 0)
 
-        SoundEQSettings.applyBassStrength(bassProgress)
+        AudioEffectManager.applyBassStrength(bassProgress)
 
-        binding.sbBass.progressDrawable.setTint(SoundEQSettings.mainColor)
-        binding.sbBass.thumb.setTint(SoundEQSettings.mainColor)
+        binding.sbBass.progressDrawable.setTint(AudioEffectManager.mainColor)
+        binding.sbBass.thumb.setTint(AudioEffectManager.mainColor)
         binding.sbBass.progress = bassProgress
 
         binding.sbBass.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                SoundEQSettings.applyBassStrength(progress, prefs)
+                AudioEffectManager.applyBassStrength(progress, prefs)
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
@@ -397,15 +396,15 @@ class SettingFragment : Fragment() {
     private fun initVirtualizerSeekbar() {
         val virtualizerProgress = prefs.getInt("VIRTUALIZER", 0)
 
-        SoundEQSettings.applyVirtualizerStrength(virtualizerProgress)
+        AudioEffectManager.applyVirtualizerStrength(virtualizerProgress)
 
-        binding.sbVirtualizer.progressDrawable.setTint(SoundEQSettings.mainColor)
-        binding.sbVirtualizer.thumb.setTint(SoundEQSettings.mainColor)
+        binding.sbVirtualizer.progressDrawable.setTint(AudioEffectManager.mainColor)
+        binding.sbVirtualizer.thumb.setTint(AudioEffectManager.mainColor)
         binding.sbVirtualizer.progress = virtualizerProgress
 
         binding.sbVirtualizer.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                SoundEQSettings.applyVirtualizerStrength(progress, prefs)
+                AudioEffectManager.applyVirtualizerStrength(progress, prefs)
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit

--- a/app/src/main/java/com/hero/ziggymusic/view/main/setting/SoundEQSettings.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/setting/SoundEQSettings.kt
@@ -5,12 +5,27 @@ import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
 import android.media.audiofx.PresetReverb
 import android.media.audiofx.Virtualizer
+import androidx.core.content.edit
 import androidx.core.graphics.toColorInt
 import com.hero.ziggymusic.audio.AudioProcessorChainController
+import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_BASS
 import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_HEAD_TRACKING_ENABLED
 import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_SPATIAL_ENABLED
+import com.hero.ziggymusic.view.main.setting.SettingFragment.Companion.KEY_VIRTUALIZER
 
 object SoundEQSettings {
+    var equalizer: Equalizer? = null
+        private set
+    var bassBoost: BassBoost? = null
+        private set
+    var virtualizer: Virtualizer? = null
+        private set
+    var reverb: PresetReverb? = null
+        private set
+
+    var mainColor: Int = "#00ffee".toColorInt()
+        private set
+
     private val bandGainsDb = FloatArray(5)
 
     /**
@@ -19,10 +34,89 @@ object SoundEQSettings {
      * @param mediaSession media session을 나타내는 정수값.
      */
     fun init(mediaSession: Int) {
-        SettingFragment.equalizer = Equalizer(1, mediaSession)
-        SettingFragment.bassBoost = BassBoost(1, mediaSession)
-        SettingFragment.virtualizer = Virtualizer(1, mediaSession)
-        SettingFragment.reverb = PresetReverb(1, mediaSession)
+        release()
+
+        runCatching { Equalizer(1, mediaSession) }.onSuccess { equalizer = it }
+        runCatching { BassBoost(1, mediaSession) }.onSuccess { bassBoost = it }
+        runCatching { Virtualizer(1, mediaSession) }.onSuccess { virtualizer = it }
+        runCatching { PresetReverb(1, mediaSession) }.onSuccess { reverb = it }
+    }
+
+    fun setEnabledFromPrefs(prefs: SharedPreferences) {
+        val enabled = prefs.getBoolean("ENABLED", false)
+        val reverbPreset = prefs.getInt("REVERB", 0)
+        val bassProgress = prefs.getInt(KEY_BASS, 0)
+        val virtualizerProgress = prefs.getInt(KEY_VIRTUALIZER, 0)
+
+        equalizer?.enabled = enabled
+        reverb?.enabled = enabled && reverbPreset != 0
+        bassBoost?.enabled = enabled && bassProgress > 0
+        virtualizer?.enabled = enabled && virtualizerProgress > 0
+    }
+
+    fun applyBassStrength(progress: Int, prefs: SharedPreferences? = null) {
+        prefs?.edit { putInt(KEY_BASS, progress) }
+
+        bassBoost?.let { effect ->
+            if (effect.strengthSupported) {
+                effect.setStrength((progress * 15).toShort())
+            }
+        }
+
+        prefs?.let { setEnabledFromPrefs(it) }
+    }
+
+    fun applyVirtualizerStrength(progress: Int, prefs: SharedPreferences? = null) {
+        prefs?.edit { putInt(KEY_VIRTUALIZER, progress) }
+
+        virtualizer?.let { effect ->
+            if (effect.strengthSupported) {
+                effect.setStrength((progress * 15).toShort())
+            }
+        }
+
+        prefs?.let { setEnabledFromPrefs(it) }
+    }
+
+    fun applyReverbPreset(position: Int, prefs: SharedPreferences? = null) {
+        prefs?.edit { putInt("REVERB", position) }
+        reverb?.preset = position.toShort()
+        prefs?.let { setEnabledFromPrefs(it) }
+    }
+
+    fun applyEqualizerBandLevel(
+        bandIndex: Int,
+        level: Short,
+    ) {
+        equalizer?.setBandLevel(bandIndex.toShort(), level)
+    }
+
+    fun useEqualizerPreset(presetIndex: Int) {
+        equalizer?.usePreset(presetIndex.toShort())
+    }
+
+    fun getBandLevel(bandIndex: Int): Short? {
+        return equalizer?.getBandLevel(bandIndex.toShort())
+    }
+
+    fun getCenterFreq(bandIndex: Int): Int? {
+        return equalizer?.getCenterFreq(bandIndex.toShort())
+    }
+
+    fun getBandLevelRange(): ShortArray? {
+        return equalizer?.bandLevelRange
+    }
+
+    fun getNumberOfBands(): Int {
+        return equalizer?.numberOfBands?.toInt() ?: 0
+    }
+
+    fun getNumberOfPresets(): Int {
+        return equalizer?.numberOfPresets?.toInt() ?: 0
+    }
+
+    fun getPresetName(index: Int): String? {
+        return equalizer?.getPresetName(index.toShort())
     }
 
     fun setBandGain(bandIndex: Int, gainDb: Float) {
@@ -88,6 +182,11 @@ object SoundEQSettings {
             val gainDb = mapEqProgressToDb(progress, eqMaxFromUi)
             setBandGain(bandIndex, gainDb)
         }
+
+        applyBassStrength(prefs.getInt(KEY_BASS, 0), null)
+        applyVirtualizerStrength(prefs.getInt(KEY_VIRTUALIZER, 0), null)
+        applyReverbPreset(prefs.getInt("REVERB", 0), null)
+        setEnabledFromPrefs(prefs)
     }
 
     private fun mapEqProgressToDb(progress: Int, max: Int): Float {
@@ -96,16 +195,15 @@ object SoundEQSettings {
         return (normalized * 24.0f) - 12.0f
     }
 
-    /**
-     * SoundEQ UI의 main color를 설정.
-     *
-     * @param color "#RRGGBB" or "#AARRGGBB" 형식의 color string.
-     */
-    fun setColor(color: String) {
-        try {
-            SettingFragment.mainColor = color.toColorInt()
-        } catch (_: Exception) {
-            // Handle parsing exceptions
-        }
+    fun release() {
+        runCatching { equalizer?.release() }
+        runCatching { bassBoost?.release() }
+        runCatching { virtualizer?.release() }
+        runCatching { reverb?.release() }
+
+        equalizer = null
+        bassBoost = null
+        virtualizer = null
+        reverb = null
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/setting/SoundEQVerticalSeekbar.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/setting/SoundEQVerticalSeekbar.kt
@@ -1,83 +1,91 @@
 package com.hero.ziggymusic.view.main.setting
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.widget.SeekBar
 import androidx.appcompat.widget.AppCompatSeekBar
+import androidx.appcompat.R
 
-class SoundEQVerticalSeekbar(
-    context: Context
-): AppCompatSeekBar(context) {
-    var shouldChange = false
-    var bandIndex: Int = 0
+class SoundEQVerticalSeekbar @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.seekBarStyle,
+) : AppCompatSeekBar(context, attrs, defStyleAttr) {
+    var isTrackingTouch: Boolean = false
+        private set
 
-    constructor(context: Context, attrs: AttributeSet) : this(context)
-    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : this(context)
-
-    init {
-        // vertical seekbar value to dB mapping example: progress 0..100 -> -12dB..+12dB
-        max = 100
-        progress = 50
-        setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                if (!fromUser) return
-                val gainDb = (progress - 50) * (12.0f / 50.0f)
-                SoundEQSettings.setBandGain(bandIndex, gainDb)
-            }
-            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
-            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
-        })
-    }
-
-    override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
-        super.onSizeChanged(height, width, oldHeight, oldWidth)
-    }
-
-    @Synchronized
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(heightMeasureSpec, widthMeasureSpec)
         setMeasuredDimension(measuredHeight, measuredWidth)
     }
 
-    @Synchronized
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(h, w, oldh, oldw)
+    }
+
     override fun onDraw(canvas: Canvas) {
-        canvas.rotate(-90.0F)
-        canvas.translate(-height.toFloat(), 0F)
+        canvas.rotate(-90f)
+        canvas.translate(-height.toFloat(), 0f)
         super.onDraw(canvas)
     }
 
-    fun updateThumb() {
-        onSizeChanged(width, height, 0, 0)
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        if (!isEnabled) { return false }
-        shouldChange = true
+        if (!isEnabled) return false
 
-        when (event.action) {
-            MotionEvent.ACTION_DOWN,
-            MotionEvent.ACTION_MOVE,
-            MotionEvent.ACTION_UP -> {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
                 parent?.requestDisallowInterceptTouchEvent(true)
-                progress = max - (max * event.y / height).toInt()
-                onSizeChanged(width, height, 0, 0)
+                isTrackingTouch = true
+                updateProgressFromTouch(event.y)
+                performClick()
+                return true
             }
+
+            MotionEvent.ACTION_MOVE -> {
+                isTrackingTouch = true
+                updateProgressFromTouch(event.y)
+                return true
+            }
+
+            MotionEvent.ACTION_UP -> {
+                updateProgressFromTouch(event.y)
+                parent?.requestDisallowInterceptTouchEvent(false)
+                isTrackingTouch = false
+                return true
+            }
+
             MotionEvent.ACTION_CANCEL -> {
                 parent?.requestDisallowInterceptTouchEvent(false)
+                isTrackingTouch = false
+                return true
             }
         }
 
-        shouldChange = true
+        return super.onTouchEvent(event)
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
         return true
     }
 
-    @Synchronized
-    override fun setProgress(progress: Int) {
-        super.setProgress(progress)
-        shouldChange = false
+    fun refreshThumbState() {
+        refreshDrawableState()
+        invalidate()
+    }
+
+    private fun updateProgressFromTouch(y: Float) {
+        if (height <= 0 || max <= 0) return
+
+        val progressFromTouch = max - (max * y / height).toInt()
+        val newProgress = progressFromTouch.coerceIn(0, max)
+
+        super.setProgress(newProgress)
+
+        // 세로 SeekBar에서는 progress 변경 후 내부 drawable bounds 갱신이 필요할 수 있음
+        onSizeChanged(width, height, 0, 0)
+
+        invalidate()
     }
 }


### PR DESCRIPTION
# PR 내용
- SettingFragment에서 AudioEffect 인스턴스 직접 관리하던 구조를 제거하고 SoundEQSettings 중심으로 정리
- Equalizer/BassBoost/Virtualizer/Reverb 생성 및 release 책임을 SoundEQSettings로 일원화
- enabled 상태 판정을 setEnabledFromPrefs() 기준으로 통합하여 설정 적용 흐름 개선
- Spatial / HeadTracking 초기 반영 및 listener 로직 정리 (stale 값 사용 문제 개선)
- Vertical SeekBar를 커스텀 View로 분리하여 UI 책임 분리 및 재사용성 개선
- 터치 기반 progress 계산 및 Thumb 위치 보정으로 SeekBar 조작 정확도 개선
- `SoundEQSettings`의 파일명을 `AudioEffectManager`로 변경