### PR TITLE
[ Fix ] Foreground Service 시작 안정화 및 Media3 기반 재생 제어 리팩토링

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,13 +43,18 @@
             android:exported="false"
             android:foregroundServiceType="mediaPlayback">
             <intent-filter>
-                <action android:name="com.hero.ziggymusic.PLAY_NEW_MUSIC" />
-                <action android:name="com.hero.ziggymusic.PLAY" />
-                <action android:name="com.hero.ziggymusic.PAUSE" />
-                <action android:name="com.hero.ziggymusic.SKIP_PREV" />
-                <action android:name="com.hero.ziggymusic.SKIP_NEXT" />
+                <action android:name="androidx.media3.session.MediaLibraryService" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".service.MusicMediaButtonReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".view.main.MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 

--- a/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.NotificationManager
 import com.hero.ziggymusic.audio.AudioDspChainHolder
 import com.hero.ziggymusic.service.MusicService
+import com.hero.ziggymusic.service.MusicServiceState
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
@@ -18,7 +19,7 @@ class ZiggyMusicApp : Application() {
         // 이전 비정상 종료로 남아 있을 수 있는 stale Notification 정리
         cancelStaleMusicNotification()
 
-        // Java/Kotlin 예외로 프로세스가 죽기 직전에 Notification 제거 시도
+        // 프로세스가 죽기 직전에 Notification 제거 시도
         defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             runCatching {
@@ -37,7 +38,7 @@ class ZiggyMusicApp : Application() {
     }
 
     private fun cancelStaleMusicNotification() {
-        MusicService.isForegroundStarted = false
+        MusicServiceState.reset()
         val manager = getSystemService(NotificationManager::class.java)
         manager.cancel(MusicService.NOTIFICATION_ID)
     }

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicMediaButtonReceiver.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicMediaButtonReceiver.kt
@@ -1,0 +1,8 @@
+package com.hero.ziggymusic.service
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaButtonReceiver
+
+@OptIn(UnstableApi::class)
+class MusicMediaButtonReceiver : MediaButtonReceiver()

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicMediaControllerConnector.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicMediaControllerConnector.kt
@@ -1,0 +1,74 @@
+package com.hero.ziggymusic.service
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class MusicMediaControllerConnector(context: Context) {
+    private val appContext = context.applicationContext
+    private var controllerFuture: ListenableFuture<MediaController>? = null
+    private var controller: MediaController? = null
+
+    suspend fun connect(): MediaController {
+        val currentController = controller
+        if (currentController?.isConnected == true) {
+            return currentController
+        }
+
+        val connectedController = getOrCreateControllerFuture().awaitController()
+        controller = connectedController
+        return connectedController
+    }
+
+    suspend fun withController(action: (MediaController) -> Unit) {
+        val controller = connect()
+        if (controller.isConnected) {
+            action(controller)
+        }
+    }
+
+    @Synchronized
+    private fun getOrCreateControllerFuture(): ListenableFuture<MediaController> {
+        controllerFuture?.let { return it }
+
+        val sessionToken = SessionToken(
+            appContext,
+            ComponentName(appContext, MusicService::class.java)
+        )
+        val future = MediaController.Builder(appContext, sessionToken).buildAsync()
+        controllerFuture = future
+        return future
+    }
+
+    private suspend fun ListenableFuture<MediaController>.awaitController(): MediaController {
+        return suspendCancellableCoroutine { continuation ->
+            addListener(
+                {
+                    try {
+                        if (continuation.isActive) {
+                            continuation.resume(Futures.getDone(this))
+                        }
+                    } catch (e: Exception) {
+                        if (continuation.isActive) {
+                            continuation.resumeWithException(e)
+                        }
+                    }
+                },
+                ContextCompat.getMainExecutor(appContext)
+            )
+        }
+    }
+
+    fun release() {
+        controller = null
+        controllerFuture?.let(MediaController::releaseFuture)
+        controllerFuture = null
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -8,16 +8,9 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.ImageDecoder
-import android.net.Uri
 import android.os.Build
 import android.util.Log
-import android.util.LruCache
 import android.view.KeyEvent
-import android.view.View
-import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
@@ -25,19 +18,13 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaStyleNotificationHelper
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.view.main.MainActivity
 import javax.inject.Inject
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @AndroidEntryPoint
 class MusicService : MediaLibraryService() {
@@ -48,13 +35,6 @@ class MusicService : MediaLibraryService() {
 
     @Volatile
     private var isExiting: Boolean = false
-
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private var albumArtLoadJob: Job? = null
-    private var currentAlbumArtBitmap: Bitmap? = null
-    private var currentAlbumArtMediaId: String? = null
-    private var loadingAlbumArtMediaId: String? = null
-    private val albumArtCache = object : LruCache<String, Bitmap>(20) {}
 
     private val playerListener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -78,7 +58,7 @@ class MusicService : MediaLibraryService() {
                 syncCurrentMusicFromPlayer()
             }
 
-            refreshAlbumArt()
+            updateNotification()
         }
     }
 
@@ -87,16 +67,16 @@ class MusicService : MediaLibraryService() {
     override fun onCreate() {
         super.onCreate()
 
-        createNotificationChannel()
-
-        startForegroundCompat()
-        MusicServiceState.onForegroundEntered()
-
         mediaLibrarySession = MediaLibrarySession.Builder(
             this,
             player,
             object : MediaLibrarySession.Callback {
             }).build()
+
+        createNotificationChannel()
+
+        startForegroundCompat()
+        MusicServiceState.onForegroundEntered()
 
         player.addListener(playerListener)
     }
@@ -120,7 +100,8 @@ class MusicService : MediaLibraryService() {
                 val mediaId = intent?.getStringExtra(EXTRA_MEDIA_ID)
                     ?: player.currentMediaItem?.mediaId
 
-                updateAlbumArt(mediaId)
+                mediaId?.let(playerModel::changedMusic)
+                updateNotification()
             }
         }
 
@@ -128,14 +109,7 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun startForegroundCompat() {
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("Ziggy Music")
-            .setContentText("음악 재생 준비 중")
-            .setSmallIcon(R.drawable.ic_music_note)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setOngoing(true)
-            .build()
+        val notification = createNotification()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             startForeground(
@@ -152,151 +126,6 @@ class MusicService : MediaLibraryService() {
         val mediaId = player.currentMediaItem?.mediaId ?: return playerModel.currentMusic
         playerModel.changedMusic(mediaId)
         return playerModel.currentMusic
-    }
-
-    private fun updateAlbumArt(mediaId: String?) {
-        albumArtLoadJob?.cancel()
-
-        if (mediaId == null) {
-            loadingAlbumArtMediaId = null
-            currentAlbumArtBitmap = null
-            currentAlbumArtMediaId = null
-            updateNotification()
-            return
-        }
-
-        playerModel.changedMusic(mediaId)
-        val currentMusic = playerModel.currentMusic
-        val albumUri = currentMusic?.getAlbumUri()
-
-        if (albumUri == null) {
-            loadingAlbumArtMediaId = null
-            currentAlbumArtBitmap = null
-            currentAlbumArtMediaId = null
-            updateNotification()
-            return
-        }
-
-        val cachedBitmap = albumArtCache.get(mediaId)
-        if (cachedBitmap != null) {
-            loadingAlbumArtMediaId = null
-            currentAlbumArtBitmap = cachedBitmap
-            currentAlbumArtMediaId = mediaId
-            updateNotification()
-            return
-        }
-
-        loadingAlbumArtMediaId = mediaId
-        currentAlbumArtBitmap = null
-        currentAlbumArtMediaId = null
-        updateNotification()
-
-        albumArtLoadJob = serviceScope.launch {
-            val bitmap = withContext(Dispatchers.IO) {
-                decodeAlbumArtForNotification(albumUri)
-            }
-
-            if (isExiting) return@launch
-
-            val latestMediaId = player.currentMediaItem?.mediaId
-            if (mediaId != latestMediaId) {
-                if (loadingAlbumArtMediaId == mediaId) {
-                    loadingAlbumArtMediaId = null
-                }
-                return@launch
-            }
-
-            loadingAlbumArtMediaId = null
-
-            if (bitmap != null) {
-                albumArtCache.put(mediaId, bitmap)
-                currentAlbumArtBitmap = bitmap
-                currentAlbumArtMediaId = mediaId
-            } else {
-                currentAlbumArtBitmap = null
-                currentAlbumArtMediaId = null
-            }
-
-            updateNotification()
-        }
-    }
-
-    private fun refreshAlbumArt() {
-        val currentMusic = syncCurrentMusicFromPlayer()
-        val newMediaId = currentMusic?.id ?: player.currentMediaItem?.mediaId
-        updateAlbumArt(newMediaId)
-    }
-
-    private fun decodeAlbumArtForNotification(albumUri: Uri?): Bitmap? {
-        if (albumUri == null) return null
-
-        return try {
-            val targetSizePx = 256
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                val source = ImageDecoder.createSource(contentResolver, albumUri)
-                ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
-                    val srcWidth = info.size.width
-                    val srcHeight = info.size.height
-
-                    val longestSide = maxOf(srcWidth, srcHeight)
-                    if (longestSide > targetSizePx) {
-                        val scale = targetSizePx.toFloat() / longestSide.toFloat()
-                        val targetWidth = (srcWidth * scale).toInt().coerceAtLeast(1)
-                        val targetHeight = (srcHeight * scale).toInt().coerceAtLeast(1)
-                        decoder.setTargetSize(targetWidth, targetHeight)
-                    }
-                }
-            } else {
-                val boundsOptions = BitmapFactory.Options().apply {
-                    inJustDecodeBounds = true
-                }
-
-                contentResolver.openInputStream(albumUri)?.use { input ->
-                    BitmapFactory.decodeStream(input, null, boundsOptions)
-                }
-
-                val sampleSize = calculateInSampleSize(
-                    width = boundsOptions.outWidth,
-                    height = boundsOptions.outHeight,
-                    reqWidth = targetSizePx,
-                    reqHeight = targetSizePx
-                )
-
-                val decodeOptions = BitmapFactory.Options().apply {
-                    inSampleSize = sampleSize
-                    inPreferredConfig = Bitmap.Config.RGB_565
-                }
-
-                contentResolver.openInputStream(albumUri)?.use { input ->
-                    BitmapFactory.decodeStream(input, null, decodeOptions)
-                }
-            }
-        } catch (e: Exception) {
-            Log.e("MusicService", "album art decode failed", e)
-            null
-        }
-    }
-
-    private fun calculateInSampleSize(
-        width: Int,
-        height: Int,
-        reqWidth: Int,
-        reqHeight: Int
-    ): Int {
-        if (width <= 0 || height <= 0) return 1
-
-        var inSampleSize = 1
-        val halfWidth = width / 2
-        val halfHeight = height / 2
-
-        while ((halfWidth / inSampleSize) >= reqWidth &&
-            (halfHeight / inSampleSize) >= reqHeight
-        ) {
-            inSampleSize *= 2
-        }
-
-        return inSampleSize.coerceAtLeast(1)
     }
 
     private fun updateNotification() {
@@ -319,8 +148,6 @@ class MusicService : MediaLibraryService() {
             manager.notify(NOTIFICATION_ID, notification)
         } catch (e: Exception) {
             Log.e("MusicService", "Notification 갱신 실패", e)
-            val manager = getSystemService(NotificationManager::class.java)
-            manager.notify(NOTIFICATION_ID, notification)
         }
     }
 
@@ -340,11 +167,6 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun createNotification(): Notification {
-        val collapsedNotificationView =
-            RemoteViews(this.packageName, R.layout.notification_player_collapsed)
-        val expandedNotificationView =
-            RemoteViews(this.packageName, R.layout.notification_player_extended)
-
         val prevIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PREVIOUS, REQ_CODE_PREV)
         val playIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PLAY, REQ_CODE_PLAY)
         val pauseIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PAUSE, REQ_CODE_PAUSE)
@@ -360,33 +182,34 @@ class MusicService : MediaLibraryService() {
         }
 
         val isPlaying = player.playWhenReady
-        setPlayPauseButtonState(
-            expandedNotificationView = expandedNotificationView,
-            isPlaying = isPlaying,
-            playIntent = playIntent,
-            pauseIntent = pauseIntent
-        )
-
-        expandedNotificationView.setOnClickPendingIntent(R.id.btnNotificationExtendedPrev, prevIntent)
-        expandedNotificationView.setOnClickPendingIntent(R.id.btnNotificationExtendedNext, nextIntent)
-
-        val currentMusic = playerModel.currentMusic
-        setMusicInNotification(
-            collapsedNotificationView = collapsedNotificationView,
-            expandedNotificationView = expandedNotificationView,
-            music = currentMusic
-        )
+        val currentMusic = playerModel.currentMusic ?: syncCurrentMusicFromPlayer()
+        val title = player.currentMediaItem?.mediaMetadata?.title
+            ?: currentMusic?.title
+            ?: getString(R.string.app_name)
+        val artist = player.currentMediaItem?.mediaMetadata?.artist
+            ?: currentMusic?.artist
+            ?: ""
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setShowWhen(false)
             .setSmallIcon(R.drawable.ic_music_note)
+            .setContentTitle(title)
+            .setContentText(artist)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setStyle(NotificationCompat.DecoratedCustomViewStyle())
+            .setStyle(
+                MediaStyleNotificationHelper.MediaStyle(mediaLibrarySession)
+                    .setShowActionsInCompactView(0, 1, 2)
+            )
+            .addAction(R.drawable.ic_prev_button, "Previous", prevIntent)
+            .addAction(
+                if (isPlaying) R.drawable.ic_pause_button else R.drawable.ic_play_button,
+                if (isPlaying) "Pause" else "Play",
+                if (isPlaying) pauseIntent else playIntent
+            )
+            .addAction(R.drawable.ic_next_button, "Next", nextIntent)
             .setColor(ContextCompat.getColor(this, R.color.dark_black))
             .setColorized(true)
-            .setCustomContentView(collapsedNotificationView)
-            .setCustomBigContentView(expandedNotificationView)
             .setContentIntent(notificationTouchIntent)
             .setOngoing(true)
             .build()
@@ -406,108 +229,6 @@ class MusicService : MediaLibraryService() {
             requestCode,
             intent,
             PendingIntent.FLAG_IMMUTABLE
-        )
-    }
-
-    private fun setPlayPauseButtonState(
-        expandedNotificationView: RemoteViews,
-        isPlaying: Boolean,
-        playIntent: PendingIntent,
-        pauseIntent: PendingIntent
-    ) {
-        if (isPlaying) {
-            expandedNotificationView.setImageViewResource(
-                R.id.btnNotificationExtendedPlay,
-                R.drawable.ic_pause_button
-            )
-            expandedNotificationView.setOnClickPendingIntent(
-                R.id.btnNotificationExtendedPlay,
-                pauseIntent
-            )
-        } else {
-            expandedNotificationView.setImageViewResource(
-                R.id.btnNotificationExtendedPlay,
-                R.drawable.ic_play_button
-            )
-            expandedNotificationView.setOnClickPendingIntent(
-                R.id.btnNotificationExtendedPlay,
-                playIntent
-            )
-        }
-    }
-
-    private fun setMusicInNotification(
-        collapsedNotificationView: RemoteViews,
-        expandedNotificationView: RemoteViews,
-        music: MusicModel?
-    ) {
-        val currentMusicId = music?.id
-        val albumBitmap = if (currentAlbumArtMediaId == currentMusicId) {
-            currentAlbumArtBitmap
-        } else {
-            null
-        }
-        val isAlbumArtLoading = loadingAlbumArtMediaId == currentMusicId
-
-        when {
-            albumBitmap != null -> {
-                collapsedNotificationView.setViewVisibility(R.id.ivNotificationAlbum, View.VISIBLE)
-                expandedNotificationView.setViewVisibility(R.id.ivNotificationExtendedAlbum, View.VISIBLE)
-
-                collapsedNotificationView.setImageViewBitmap(R.id.ivNotificationAlbum, albumBitmap)
-                expandedNotificationView.setImageViewBitmap(
-                    R.id.ivNotificationExtendedAlbum,
-                    albumBitmap
-                )
-            }
-
-            isAlbumArtLoading -> {
-                collapsedNotificationView.setViewVisibility(R.id.ivNotificationAlbum, View.VISIBLE)
-                expandedNotificationView.setViewVisibility(R.id.ivNotificationExtendedAlbum, View.VISIBLE)
-
-                collapsedNotificationView.setImageViewResource(
-                    R.id.ivNotificationAlbum,
-                    android.R.color.transparent
-                )
-                expandedNotificationView.setImageViewResource(
-                    R.id.ivNotificationExtendedAlbum,
-                    android.R.color.transparent
-                )
-            }
-
-            else -> {
-                collapsedNotificationView.setViewVisibility(R.id.ivNotificationAlbum, View.VISIBLE)
-                expandedNotificationView.setViewVisibility(R.id.ivNotificationExtendedAlbum, View.VISIBLE)
-
-                collapsedNotificationView.setImageViewResource(
-                    R.id.ivNotificationAlbum,
-                    R.drawable.ic_no_album_image
-                )
-                expandedNotificationView.setImageViewResource(
-                    R.id.ivNotificationExtendedAlbum,
-                    R.drawable.ic_no_album_image
-                )
-            }
-        }
-
-        collapsedNotificationView.setTextViewText(R.id.tvNotificationTitle, music?.title ?: "")
-        collapsedNotificationView.setTextViewText(R.id.tvNotificationArtist, music?.artist ?: "")
-
-        expandedNotificationView.setTextViewText(
-            R.id.tvNotificationExtendedTitle,
-            music?.title ?: ""
-        )
-        expandedNotificationView.setTextViewText(
-            R.id.tvNotificationExtendedArtist,
-            music?.artist ?: ""
-        )
-        expandedNotificationView.setImageViewResource(
-            R.id.btnNotificationExtendedPrev,
-            R.drawable.ic_prev_button
-        )
-        expandedNotificationView.setImageViewResource(
-            R.id.btnNotificationExtendedNext,
-            R.drawable.ic_next_button
         )
     }
 
@@ -544,11 +265,6 @@ class MusicService : MediaLibraryService() {
 
     override fun onDestroy() {
         MusicServiceState.reset()
-
-        albumArtLoadJob?.cancel()
-        serviceScope.cancel()
-        currentAlbumArtBitmap = null
-        currentAlbumArtMediaId = null
 
         stopForeground(STOP_FOREGROUND_REMOVE)
 

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -149,7 +149,10 @@ class MusicService : MediaLibraryService() {
             }
 
             ACTION_REFRESH_NOTIFICATION, null -> {
-                refreshAlbumArt()
+                val mediaId = intent?.getStringExtra(EXTRA_MEDIA_ID)
+                    ?: player.currentMediaItem?.mediaId
+
+                updateAlbumArt(mediaId)
             }
         }
 

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -15,6 +15,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.util.LruCache
+import android.view.KeyEvent
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
@@ -27,11 +28,8 @@ import androidx.media3.session.MediaSession
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
-import com.hero.ziggymusic.event.Event
-import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.view.main.MainActivity
 import javax.inject.Inject
-import com.squareup.otto.Subscribe
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -94,8 +92,6 @@ class MusicService : MediaLibraryService() {
         startForegroundCompat()
         MusicServiceState.onForegroundEntered()
 
-        EventBus.getInstance().register(this)
-
         mediaLibrarySession = MediaLibrarySession.Builder(
             this,
             player,
@@ -120,32 +116,6 @@ class MusicService : MediaLibraryService() {
         Log.d("MusicServiceAction", "action = ${intent?.action}")
 
         when (intent?.action) {
-            PLAY -> {
-                if (!player.playWhenReady) {
-                    Log.d("onStartCommand", "PLAY")
-                    player.play()
-                }
-                updateNotification()
-            }
-
-            PAUSE -> {
-                if (player.playWhenReady) {
-                    Log.d("onStartCommand", "PAUSE")
-                    player.pause()
-                }
-                updateNotification()
-            }
-
-            SKIP_PREV -> {
-                Log.d("onStartCommand", "SKIP_PREV")
-                player.seekToPrevious()
-            }
-
-            SKIP_NEXT -> {
-                Log.d("onStartCommand", "SKIP_NEXT")
-                player.seekToNext()
-            }
-
             ACTION_REFRESH_NOTIFICATION, null -> {
                 val mediaId = intent?.getStringExtra(EXTRA_MEDIA_ID)
                     ?: player.currentMediaItem?.mediaId
@@ -345,37 +315,12 @@ class MusicService : MediaLibraryService() {
         }
 
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(
-                    NOTIFICATION_ID,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-                )
-            } else {
-                startForeground(NOTIFICATION_ID, notification)
-            }
-        } catch (e: Exception) {
-            Log.e("MusicService", "startForeground로 알림 갱신 실패", e)
             val manager = getSystemService(NotificationManager::class.java)
             manager.notify(NOTIFICATION_ID, notification)
-        }
-    }
-
-    @Subscribe
-    fun onEvent(event: Event) {
-        when (event.getEvent()) {
-            "PLAY" -> {
-                player.play()
-            }
-            "PAUSE" -> {
-                player.pause()
-            }
-            "SKIP_PREV" -> {
-                player.seekToPrevious()
-            }
-            "SKIP_NEXT" -> {
-                player.seekToNext()
-            }
+        } catch (e: Exception) {
+            Log.e("MusicService", "Notification 갱신 실패", e)
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.notify(NOTIFICATION_ID, notification)
         }
     }
 
@@ -400,42 +345,10 @@ class MusicService : MediaLibraryService() {
         val expandedNotificationView =
             RemoteViews(this.packageName, R.layout.notification_player_extended)
 
-        val prevIntent = Intent(this, MusicService::class.java).run {
-            action = SKIP_PREV
-            PendingIntent.getService(
-                this@MusicService,
-                REQ_CODE_PREV,
-                this,
-                PendingIntent.FLAG_IMMUTABLE
-            )
-        }
-        val playIntent = Intent(this, MusicService::class.java).run {
-            action = PLAY
-            PendingIntent.getService(
-                this@MusicService,
-                REQ_CODE_PLAY,
-                this,
-                PendingIntent.FLAG_IMMUTABLE
-            )
-        }
-        val pauseIntent = Intent(this, MusicService::class.java).run {
-            action = PAUSE
-            PendingIntent.getService(
-                this@MusicService,
-                REQ_CODE_PAUSE,
-                this,
-                PendingIntent.FLAG_IMMUTABLE
-            )
-        }
-        val nextIntent = Intent(this, MusicService::class.java).run {
-            action = SKIP_NEXT
-            PendingIntent.getService(
-                this@MusicService,
-                REQ_CODE_NEXT,
-                this,
-                PendingIntent.FLAG_IMMUTABLE
-            )
-        }
+        val prevIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PREVIOUS, REQ_CODE_PREV)
+        val playIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PLAY, REQ_CODE_PLAY)
+        val pauseIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PAUSE, REQ_CODE_PAUSE)
+        val nextIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_NEXT, REQ_CODE_NEXT)
         val notificationTouchIntent = Intent(this, MainActivity::class.java).run {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             PendingIntent.getActivity(
@@ -477,6 +390,23 @@ class MusicService : MediaLibraryService() {
             .setContentIntent(notificationTouchIntent)
             .setOngoing(true)
             .build()
+    }
+
+    private fun mediaButtonPendingIntent(keyCode: Int, requestCode: Int): PendingIntent {
+        val intent = Intent(Intent.ACTION_MEDIA_BUTTON).apply {
+            setClass(this@MusicService, MusicMediaButtonReceiver::class.java)
+            putExtra(
+                Intent.EXTRA_KEY_EVENT,
+                KeyEvent(KeyEvent.ACTION_DOWN, keyCode)
+            )
+        }
+
+        return PendingIntent.getBroadcast(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
     }
 
     private fun setPlayPauseButtonState(
@@ -629,7 +559,6 @@ class MusicService : MediaLibraryService() {
             mediaLibrarySession.release()
         }
 
-        EventBus.getInstance().unregister(this)
         super.onDestroy()
     }
 
@@ -637,10 +566,6 @@ class MusicService : MediaLibraryService() {
         const val CHANNEL_ID = "MusicChannel"
         const val NOTIFICATION_ID = 1
 
-        const val PLAY = "com.hero.ziggymusic.PLAY"
-        const val PAUSE = "com.hero.ziggymusic.PAUSE"
-        const val SKIP_PREV = "com.hero.ziggymusic.SKIP_PREV"
-        const val SKIP_NEXT = "com.hero.ziggymusic.SKIP_NEXT"
         const val ACTION_REFRESH_NOTIFICATION = "com.hero.ziggymusic.REFRESH_NOTIFICATION"
         const val EXTRA_MEDIA_ID = "extra_media_id"
 

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -11,10 +11,12 @@ import android.content.pm.ServiceInfo
 import android.os.Build
 import android.util.Log
 import android.view.KeyEvent
+import androidx.annotation.OptIn
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
@@ -166,6 +168,7 @@ class MusicService : MediaLibraryService() {
         }
     }
 
+    @OptIn(UnstableApi::class)
     private fun createNotification(): Notification {
         val prevIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PREVIOUS, REQ_CODE_PREV)
         val playIntent = mediaButtonPendingIntent(KeyEvent.KEYCODE_MEDIA_PLAY, REQ_CODE_PLAY)

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -92,8 +92,7 @@ class MusicService : MediaLibraryService() {
         createNotificationChannel()
 
         startForegroundCompat()
-        isForegroundStarted = true
-        MusicServiceLauncher.onForegroundEntered()
+        MusicServiceState.onForegroundEntered()
 
         EventBus.getInstance().register(this)
 
@@ -113,10 +112,9 @@ class MusicService : MediaLibraryService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
-        if (!isForegroundStarted) {
+        if (!MusicServiceState.isForegroundStarted) {
             startForegroundCompat()
-            isForegroundStarted = true
-            MusicServiceLauncher.onForegroundEntered()
+            MusicServiceState.onForegroundEntered()
         }
 
         Log.d("MusicServiceAction", "action = ${intent?.action}")
@@ -332,7 +330,7 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun updateNotification() {
-        if (isExiting || !isForegroundStarted) return
+        if (isExiting || !MusicServiceState.isForegroundStarted) return
 
         val notification = try {
             createNotification()
@@ -615,8 +613,7 @@ class MusicService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
-        isForegroundStarted = false
-        MusicServiceLauncher.onServiceDestroyed()
+        MusicServiceState.reset()
 
         albumArtLoadJob?.cancel()
         serviceScope.cancel()
@@ -646,9 +643,6 @@ class MusicService : MediaLibraryService() {
         const val SKIP_NEXT = "com.hero.ziggymusic.SKIP_NEXT"
         const val ACTION_REFRESH_NOTIFICATION = "com.hero.ziggymusic.REFRESH_NOTIFICATION"
         const val EXTRA_MEDIA_ID = "extra_media_id"
-
-        @Volatile
-        var isForegroundStarted: Boolean = false
 
         const val REQ_CODE_PREV = 100
         const val REQ_CODE_PLAY = 101

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicServiceController.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicServiceController.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
 
-object MusicServiceLauncher {
+object MusicServiceController {
     fun refreshIfRunning(
         context: Context,
         mediaId: String? = null

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicServiceLauncher.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicServiceLauncher.kt
@@ -5,14 +5,11 @@ import android.content.Intent
 import androidx.core.content.ContextCompat
 
 object MusicServiceLauncher {
-    @Volatile
-    private var isStartRequested: Boolean = false
-
     fun refreshIfRunning(
         context: Context,
         mediaId: String? = null
     ) {
-        if (!MusicService.isForegroundStarted) return
+        if (!MusicServiceState.isForegroundStarted) return
 
         dispatchAction(
             context = context,
@@ -36,19 +33,10 @@ object MusicServiceLauncher {
             }
         }
 
-        if (MusicService.isForegroundStarted) {
+        if (MusicServiceState.isForegroundStarted) {
             appContext.startService(intent)
-        } else if (startIfNeeded && !isStartRequested) {
-            isStartRequested = true
+        } else if (startIfNeeded && MusicServiceState.markStartRequested()) {
             ContextCompat.startForegroundService(appContext, intent)
         }
-    }
-
-    fun onForegroundEntered() {
-        isStartRequested = false
-    }
-
-    fun onServiceDestroyed() {
-        isStartRequested = false
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicServiceLauncher.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicServiceLauncher.kt
@@ -8,14 +8,25 @@ object MusicServiceLauncher {
     @Volatile
     private var isStartRequested: Boolean = false
 
-    fun startOrRefresh(context: Context) {
-        dispatchAction(context, MusicService.ACTION_REFRESH_NOTIFICATION)
+    fun refreshIfRunning(
+        context: Context,
+        mediaId: String? = null
+    ) {
+        if (!MusicService.isForegroundStarted) return
+
+        dispatchAction(
+            context = context,
+            action = MusicService.ACTION_REFRESH_NOTIFICATION,
+            mediaId = mediaId,
+            startIfNeeded = false
+        )
     }
 
     fun dispatchAction(
         context: Context,
         action: String,
-        mediaId: String? = null
+        mediaId: String? = null,
+        startIfNeeded: Boolean = true
     ) {
         val appContext = context.applicationContext
         val intent = Intent(appContext, MusicService::class.java).apply {
@@ -25,9 +36,9 @@ object MusicServiceLauncher {
             }
         }
 
-        if (MusicService.isForegroundStarted || isStartRequested) {
+        if (MusicService.isForegroundStarted) {
             appContext.startService(intent)
-        } else {
+        } else if (startIfNeeded && !isStartRequested) {
             isStartRequested = true
             ContextCompat.startForegroundService(appContext, intent)
         }

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicServiceState.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicServiceState.kt
@@ -1,0 +1,29 @@
+package com.hero.ziggymusic.service
+
+internal object MusicServiceState {
+    @Volatile
+    var isForegroundStarted: Boolean = false
+        private set
+
+    @Volatile
+    private var isStartRequested: Boolean = false
+
+    @Synchronized
+    fun markStartRequested(): Boolean {
+        if (isForegroundStarted || isStartRequested) return false
+        isStartRequested = true
+        return true
+    }
+
+    @Synchronized
+    fun onForegroundEntered() {
+        isForegroundStarted = true
+        isStartRequested = false
+    }
+
+    @Synchronized
+    fun reset() {
+        isForegroundStarted = false
+        isStartRequested = false
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -40,7 +40,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.hero.ziggymusic.service.MusicService
-import com.hero.ziggymusic.service.MusicServiceLauncher
+import com.hero.ziggymusic.service.MusicServiceController
 import com.hero.ziggymusic.view.main.model.MainTitle
 import com.hero.ziggymusic.view.main.musiclist.MusicListFragment
 import com.hero.ziggymusic.view.main.myplaylist.MyPlaylistFragment
@@ -185,7 +185,7 @@ class MainActivity : AppCompatActivity(),
 
     fun playMusic(musicId: String) {
         playerController.changeMusic(musicId)
-        MusicServiceLauncher.dispatchAction(
+        MusicServiceController.dispatchAction(
             context = this,
             action = MusicService.ACTION_REFRESH_NOTIFICATION,
             mediaId = musicId
@@ -219,13 +219,13 @@ class MainActivity : AppCompatActivity(),
 
     // 서비스를 시작하는 메서드
     private fun refreshMusicServiceIfRunning() {
-        MusicServiceLauncher.refreshIfRunning(this)
+        MusicServiceController.refreshIfRunning(this)
     }
 
     private fun startMusicServiceIfNotificationAllowed() {
         if (!hasNotificationPermission()) return
 
-        MusicServiceLauncher.dispatchAction(
+        MusicServiceController.dispatchAction(
             context = this,
             action = MusicService.ACTION_REFRESH_NOTIFICATION
         )

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -142,30 +142,17 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onStart() {
-        musicServiceStart()
-
         super.onStart()
     }
 
     override fun onResume() {
         super.onResume()
 
-        val audioPermissionGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.READ_MEDIA_AUDIO
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            ) == PackageManager.PERMISSION_GRANTED
-        }
-
-        if (audioPermissionGranted) {
+        if (hasAudioPermission()) {
             playerController.startPlayer(
                 playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty()
             )
+            startMusicServiceIfNotificationAllowed()
         }
     }
 
@@ -198,7 +185,11 @@ class MainActivity : AppCompatActivity(),
 
     fun playMusic(musicId: String) {
         playerController.changeMusic(musicId)
-        MusicServiceLauncher.dispatchAction(this, MusicService.ACTION_REFRESH_NOTIFICATION, musicId)
+        MusicServiceLauncher.dispatchAction(
+            context = this,
+            action = MusicService.ACTION_REFRESH_NOTIFICATION,
+            mediaId = musicId
+        )
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
@@ -227,15 +218,24 @@ class MainActivity : AppCompatActivity(),
     }
 
     // 서비스를 시작하는 메서드
-    private fun musicServiceStart() {
-        MusicServiceLauncher.startOrRefresh(this)
+    private fun refreshMusicServiceIfRunning() {
+        MusicServiceLauncher.refreshIfRunning(this)
+    }
+
+    private fun startMusicServiceIfNotificationAllowed() {
+        if (!hasNotificationPermission()) return
+
+        MusicServiceLauncher.dispatchAction(
+            context = this,
+            action = MusicService.ACTION_REFRESH_NOTIFICATION
+        )
     }
 
     @Subscribe
     fun doEvent(event: Event) {
         when(event.getEvent()) {
             "PLAY_NEW_MUSIC" -> { // 새로운 음원이 재생
-                musicServiceStart()
+                refreshMusicServiceIfRunning()
             }
             "PLAY", "PAUSE" -> { // 재생(기존 음원), 일시 정지
                 Log.d("MainActivity", "doEvent - PLAY PAUSE: ${player.isPlaying}")
@@ -244,7 +244,7 @@ class MainActivity : AppCompatActivity(),
                 } else {
                     player.play()
                 }
-                musicServiceStart()
+                refreshMusicServiceIfRunning()
             }
             "SKIP_PREV" -> { // Notification 에서 이전 곡 버튼을 누를 시
                 Log.d("MainActivity", "doEvent - SKIP_PREV: ${player.isPlaying}")
@@ -264,7 +264,7 @@ class MainActivity : AppCompatActivity(),
                 }
 
                 setPlayerListener()
-                musicServiceStart()
+                refreshMusicServiceIfRunning()
             }
             "SKIP_NEXT" -> { // Notification 에서 다음 곡 버튼을 누를 시
                 Log.d("MainActivity", "doEvent - SKIP_NEXT: ${player.isPlaying}")
@@ -277,7 +277,7 @@ class MainActivity : AppCompatActivity(),
                     seekTo(nextIndex, 0)
                 }
                 setPlayerListener()
-                musicServiceStart()
+                refreshMusicServiceIfRunning()
             }
         }
     }
@@ -306,19 +306,20 @@ class MainActivity : AppCompatActivity(),
     private fun requestPermissions() {
         val needs = mutableListOf<String>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (checkSelfPermission(Manifest.permission.READ_MEDIA_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+            if (!hasAudioPermission()) {
                 needs += Manifest.permission.READ_MEDIA_AUDIO
             }
-            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            if (!hasNotificationPermission()) {
                 needs += Manifest.permission.POST_NOTIFICATIONS
             }
         } else {
-            if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            if (!hasAudioPermission()) {
                 needs += Manifest.permission.READ_EXTERNAL_STORAGE
             }
         }
         if (needs.isEmpty()) {
             playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
+            startMusicServiceIfNotificationAllowed()
         } else {
             permissionLauncher.launch(needs.toTypedArray())
         }
@@ -326,16 +327,9 @@ class MainActivity : AppCompatActivity(),
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
-    ) { result ->
-        val audioGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-            result[Manifest.permission.READ_MEDIA_AUDIO] == true
-        else
-            result[Manifest.permission.READ_EXTERNAL_STORAGE] == true
-
-        val notifGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-            result[Manifest.permission.POST_NOTIFICATIONS] == true
-        else
-            true
+    ) { _ ->
+        val audioGranted = hasAudioPermission()
+        val notifGranted = hasNotificationPermission()
 
         if (!audioGranted) {
             // 오디오 권한 미허용
@@ -350,6 +344,7 @@ class MainActivity : AppCompatActivity(),
 
         // 오디오 권한 허용됨 -> 핵심 기능 시작
         playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
+        startMusicServiceIfNotificationAllowed()
 
         // 알림 권한 선택적 처리
         if (!notifGranted) {
@@ -425,6 +420,24 @@ class MainActivity : AppCompatActivity(),
             }
             .setNegativeButton("닫기", null)
             .show()
+    }
+
+    private fun hasAudioPermission(): Boolean {
+        val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+
+        return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
     }
 
     // 앱 세부 설정 화면 이동

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -27,11 +26,8 @@ import com.google.android.material.navigation.NavigationBarView
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.ActivityMainBinding
-import com.hero.ziggymusic.event.Event
-import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.view.main.setting.AudioEffectManager
 import com.hero.ziggymusic.view.main.setting.SettingFragment
-import com.squareup.otto.Subscribe
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -90,8 +86,6 @@ class MainActivity : AppCompatActivity(),
         initSoundEQSettings()
         initListeners()
         requestPermissions()
-
-        EventBus.getInstance().register(this)
     }
 
     private fun initPlayerController() {
@@ -211,17 +205,6 @@ class MainActivity : AppCompatActivity(),
         return true
     }
 
-    // 미니 플레이어에서 사용하는 버튼에 리스너 세팅
-    private fun setPlayerListener() {
-        player.removeListener(playerListener)
-        player.addListener(playerListener)
-    }
-
-    // 서비스를 시작하는 메서드
-    private fun refreshMusicServiceIfRunning() {
-        MusicServiceController.refreshIfRunning(this)
-    }
-
     private fun startMusicServiceIfNotificationAllowed() {
         if (!hasNotificationPermission()) return
 
@@ -229,57 +212,6 @@ class MainActivity : AppCompatActivity(),
             context = this,
             action = MusicService.ACTION_REFRESH_NOTIFICATION
         )
-    }
-
-    @Subscribe
-    fun doEvent(event: Event) {
-        when(event.getEvent()) {
-            "PLAY_NEW_MUSIC" -> { // 새로운 음원이 재생
-                refreshMusicServiceIfRunning()
-            }
-            "PLAY", "PAUSE" -> { // 재생(기존 음원), 일시 정지
-                Log.d("MainActivity", "doEvent - PLAY PAUSE: ${player.isPlaying}")
-                if (player.isPlaying) {
-                    player.pause()
-                } else {
-                    player.play()
-                }
-                refreshMusicServiceIfRunning()
-            }
-            "SKIP_PREV" -> { // Notification 에서 이전 곡 버튼을 누를 시
-                Log.d("MainActivity", "doEvent - SKIP_PREV: ${player.isPlaying}")
-                player.run {
-                    val prevIndex = if (currentMediaItemIndex - 1 in 0 until mediaItemCount) {
-                        currentMediaItemIndex - 1
-                    } else {
-                        // 전 곡 반복 재생 모드에서 0번 트랙에서 뒤로 갈 때 마지막 트랙으로 이동
-                        if (player.repeatMode == Player.REPEAT_MODE_ALL) {
-                            mediaItemCount - 1
-                        } else {
-                            0
-                        }
-                    }
-
-                    seekTo(prevIndex, 0)
-                }
-
-                setPlayerListener()
-                refreshMusicServiceIfRunning()
-            }
-            "SKIP_NEXT" -> { // Notification 에서 다음 곡 버튼을 누를 시
-                Log.d("MainActivity", "doEvent - SKIP_NEXT: ${player.isPlaying}")
-                player.run {
-                    val nextIndex = if (currentMediaItemIndex + 1 in 0 until mediaItemCount) {
-                        currentMediaItemIndex + 1
-                    } else {
-                        0
-                    }
-                    seekTo(nextIndex, 0)
-                }
-                setPlayerListener()
-                refreshMusicServiceIfRunning()
-            }
-        }
     }
 
     private fun initStatusBarColor() {
@@ -494,9 +426,4 @@ class MainActivity : AppCompatActivity(),
         }
     }
 
-    override fun onDestroy() {
-        EventBus.getInstance().unregister(this)
-
-        super.onDestroy()
-    }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/myplaylist/MyPlaylistFragment.kt
@@ -17,7 +17,6 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.databinding.FragmentMyPlaylistBinding
 import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.ext.playMusic
-import com.hero.ziggymusic.service.MusicServiceLauncher
 import com.hero.ziggymusic.view.main.myplaylist.viewmodel.MyPlaylistUiState
 import com.hero.ziggymusic.view.main.myplaylist.viewmodel.MyPlaylistViewModel
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -31,6 +31,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
@@ -638,6 +639,14 @@ class PlayerFragment : Fragment() {
             val mediaItem = MediaItem.Builder()
                 .setMediaId(music.id)
                 .setUri(musicFileUri)
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setTitle(music.title)
+                        .setArtist(music.artist)
+                        .setAlbumTitle(music.album)
+                        .setArtworkUri(music.getAlbumUri())
+                        .build()
+                )
                 .build()
 
             ProgressiveMediaSource.Factory(defaultDataSourceFactory) // 미디어 정보를 가져오는 클래스

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -62,7 +62,7 @@ import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
-import com.hero.ziggymusic.service.MusicServiceLauncher
+import com.hero.ziggymusic.service.MusicServiceController
 import com.hero.ziggymusic.view.main.player.model.LastPlayedMedia
 
 @AndroidEntryPoint
@@ -352,7 +352,7 @@ class PlayerFragment : Fragment() {
     }
 
     private fun sendServiceAction(action: String) {
-        MusicServiceLauncher.dispatchAction(requireContext(), action)
+        MusicServiceController.dispatchAction(requireContext(), action)
     }
 
     private fun initPlayView() {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -45,10 +45,6 @@ import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
 import com.hero.ziggymusic.databinding.FragmentPlayerBinding
-import com.hero.ziggymusic.service.MusicService.Companion.PLAY
-import com.hero.ziggymusic.service.MusicService.Companion.PAUSE
-import com.hero.ziggymusic.service.MusicService.Companion.SKIP_PREV
-import com.hero.ziggymusic.service.MusicService.Companion.SKIP_NEXT
 import com.hero.ziggymusic.view.main.player.viewmodel.PlayerViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -62,7 +58,7 @@ import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
-import com.hero.ziggymusic.service.MusicServiceController
+import com.hero.ziggymusic.service.MusicMediaControllerConnector
 import com.hero.ziggymusic.view.main.player.model.LastPlayedMedia
 
 @AndroidEntryPoint
@@ -89,6 +85,7 @@ class PlayerFragment : Fragment() {
 
     private lateinit var playerMotionManager: PlayerMotionManager
     private lateinit var playerBottomSheetManager: PlayerBottomSheetManager
+    private lateinit var mediaControllerConnector: MusicMediaControllerConnector
     private var albumGradientManager: MusicAlbumArtGradientManager? = null
     private var latestAlbumBitmap: Bitmap? = null
 
@@ -129,6 +126,7 @@ class PlayerFragment : Fragment() {
         binding.music = playerModel.currentMusic
         binding.executePendingBindings()
 
+        initMediaController()
         initAudioManager()
         initPlayView()
         initPlayControlButtons()
@@ -142,6 +140,13 @@ class PlayerFragment : Fragment() {
         audioManager = requireContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
         currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         previousVolume = currentVolume
+    }
+
+    private fun initMediaController() {
+        mediaControllerConnector = MusicMediaControllerConnector(requireContext())
+        viewLifecycleOwner.lifecycleScope.launch {
+            mediaControllerConnector.connect()
+        }
     }
 
     private fun initListeners() {
@@ -334,25 +339,33 @@ class PlayerFragment : Fragment() {
     }
 
     private fun initPlayControlButtons() {
-        // 재생 or 일시정지 버튼
         binding.ivPlayPause.setOnClickListener {
-            val action =
-                if (player.isPlaying) PAUSE
-                else PLAY
-            sendServiceAction(action)
+            viewLifecycleOwner.lifecycleScope.launch {
+                mediaControllerConnector.withController { controller ->
+                    if (player.isPlaying) {
+                        controller.pause()
+                    } else {
+                        controller.play()
+                    }
+                }
+            }
         }
 
         binding.ivNext.setOnClickListener {
-            sendServiceAction(SKIP_NEXT)
+            viewLifecycleOwner.lifecycleScope.launch {
+                mediaControllerConnector.withController { controller ->
+                    controller.seekToNext()
+                }
+            }
         }
 
         binding.ivPrevious.setOnClickListener {
-            sendServiceAction(SKIP_PREV)
+            viewLifecycleOwner.lifecycleScope.launch {
+                mediaControllerConnector.withController { controller ->
+                    controller.seekToPrevious()
+                }
+            }
         }
-    }
-
-    private fun sendServiceAction(action: String) {
-        MusicServiceController.dispatchAction(requireContext(), action)
     }
 
     private fun initPlayView() {
@@ -930,6 +943,7 @@ class PlayerFragment : Fragment() {
 
         // 앨범 그라데이션 매니저 해제
         albumGradientManager = null
+        mediaControllerConnector.release()
 
         _binding = null
         super.onDestroyView()


### PR DESCRIPTION
PR 내용
- 앱 실행 직후 Foreground Service가 먼저 실행되면서 Notification 초기화 상태와 Service 상태가 어긋날 수 있는 흐름을 보완
    - Foreground Service가 제때 startForeground() 상태로 진입하지 못해 앱이 강제 종료될 수 있는 가능성을 줄임
- MusicService와 MusicServiceController가 서로의 상태나 생명주기에 직접 의존하던 구조를 개선하고, MusicServiceState를 통해 Foreground Service 시작 여부와 요청 상태를 별도로 관리하도록 리팩토링
- 플레이어 UI의 재생, 일시정지, 이전곡, 다음곡 동작을 Service Intent 기반 호출에서 Media3 MediaController 기반 호출로 전환
    - MusicService는 재생 액션 처리보다 MediaSession, Notification refresh, Foreground Service 관리 역할에 집중하도록 정리
- Notification 갱신 시 반복적으로 startForeground()를 호출하지 않고, 이미 Foreground 상태인 경우 NotificationManager.notify()를 통해 갱신하도록 변경
    - 곡 선택이나 재생 상태 변경 시 Notification이 사라졌다가 다시 생성되는 현상을 완화
- 기존 Custom Notification 대신 Media3 MediaSession 기반 표준 Media Notification 흐름을 사용하도록 대체
    - Android System UI, 잠금 화면, 미디어 출력 전환 UI와 더 자연스럽게 연동되도록 개선
- MusicMediaControllerConnector의 비동기 MediaController 연결 처리를 Kotlin coroutine 기반 API로 감싸고, ListenableFuture.get() 직접 호출로 인한 blocking 경고가 발생하지 않도록 개선