### PR TITLE
[ Fix ] release 빌드 축소 설정 및 ProGuard 규칙 보완

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,12 +66,12 @@ extensions.configure<ApplicationExtension> {
         getByName("debug") {
             isShrinkResources = false
             isMinifyEnabled = false
-            isDebuggable = false
+            isDebuggable = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         getByName("release") {
-            isShrinkResources = false
-            isMinifyEnabled = false
+            isShrinkResources = true
+            isMinifyEnabled = true
             isDebuggable = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,51 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# ------------------------------------------------------------
+# Release R8/ProGuard rules
+# ------------------------------------------------------------
+
+# Keep enough metadata for libraries that inspect annotations, generic
+# signatures, or Kotlin declarations at runtime, plus useful release stack
+# traces after minification.
+-keepattributes Signature,*Annotation*,InnerClasses,EnclosingMethod,SourceFile,LineNumberTable
+-keep class kotlin.Metadata { *; }
+
+-renamesourcefileattribute SourceFile
+
+# JNI native method names are resolved from the Java/Kotlin package, class,
+# and method names when RegisterNatives is not used. These two classes are
+# exported from app/src/main/cpp with Java_com_hero_... symbols, so their
+# binary names and native methods must not be obfuscated.
+-keep class com.hero.ziggymusic.audio.AudioProcessorChainController {
+    native <methods>;
+}
+
+-keep class com.hero.ziggymusic.audio.BufferAddressHelper {
+    native <methods>;
+}
+
+# General safety net for future JNI entry points.
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+# Data Binding calls generated binding adapters by annotation. Keep adapter
+# method names and signatures so layout binding remains stable after R8.
+-keepclassmembers class * {
+    @androidx.databinding.BindingAdapter <methods>;
+}
+
+# Otto discovers @Subscribe/@Produce methods reflectively. There are no
+# current subscribers in the project, but these rules prevent future release
+# only event-bus failures when minification is enabled.
+-keepclassmembers class * {
+    @com.squareup.otto.Subscribe <methods>;
+    @com.squareup.otto.Produce <methods>;
+}
+
+# Parcelable support used by models passed through Bundles/Intents.
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final android.os.Parcelable$Creator CREATOR;
+}


### PR DESCRIPTION
- debug 빌드에서 `isDebuggable` 옵션을 `true`로 변경하여 디버깅 활성화
- release 빌드에서 isShrinkResources, isMinifyEnabled를 활성화해 앱 용량을 줄이도록 설정
- R8 난독화 시 JNI 네이티브 메서드 연결이 깨지지 않도록 AudioProcessorChainController, BufferAddressHelper 관련 ProGuard 규칙 추가
- Data Binding, Otto 이벤트 핸들러, Parcelable, Kotlin/annotation 메타데이터 보존 규칙 추가