### PR TITLE
[ UI ] 앱 시작 시 스플래시 화면 노출 최소화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.ZiggyMusic"
         tools:targetApi="31"
-        tools:ignore="LockedOrientationActivity">
+        tools:ignore="DiscouragedApi,LockedOrientationActivity">
 
         <service
             android:name=".service.MusicService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ZiggyMusic"
-        tools:targetApi="31"
-        tools:ignore="DiscouragedApi,LockedOrientationActivity">
+        tools:targetApi="31">
 
         <service
             android:name=".service.MusicService"
@@ -54,10 +53,13 @@
             </intent-filter>
         </receiver>
 
+        <!-- MainActivity is currently phone-portrait only; keep the lint suppression scoped here. -->
         <activity
             android:name=".view.main.MainActivity"
+            android:exported="true"
             android:screenOrientation="portrait"
-            android:exported="true">
+            android:theme="@style/Theme.ZiggyMusic.Launcher"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/drawable/ic_splash_transparent.xml
+++ b/app/src/main/res/drawable/ic_splash_transparent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M0,0h48v48h-48z" />
+</vector>

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -5,8 +5,6 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
 
         <!-- Default text style -->
         <item name="android:fontFamily">@font/pretendard</item>
@@ -25,5 +23,10 @@
 
         <item name="android:statusBarColor">@color/dark_black</item>
         <item name="android:windowBackground">@color/dark_black</item>
+    </style>
+
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
+        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -5,6 +5,7 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
 
         <!-- Default text style -->
@@ -23,5 +24,6 @@
         <item name="colorOnSecondary">@color/black</item>
 
         <item name="android:statusBarColor">@color/dark_black</item>
+        <item name="android:windowBackground">@color/dark_black</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -21,6 +21,9 @@
 
         <item name="android:statusBarColor">@color/dark_black</item>
         <item name="android:windowBackground">@color/dark_black</item>
+    </style>
+
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
         <item name="android:windowDisablePreview">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -20,5 +20,7 @@
         <item name="colorOnSecondary">@color/black</item>
 
         <item name="android:statusBarColor">@color/dark_black</item>
+        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:windowDisablePreview">true</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -5,8 +5,6 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
 
         <!-- Default text style -->
         <item name="android:fontFamily">@font/pretendard</item>
@@ -25,5 +23,10 @@
 
         <item name="android:statusBarColor">@color/dark_black</item>
         <item name="android:windowBackground">@color/dark_black</item>
+    </style>
+
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
+        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -5,6 +5,7 @@
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
 
         <!-- Default text style -->
@@ -23,5 +24,6 @@
         <item name="colorOnSecondary">@color/black</item>
 
         <item name="android:statusBarColor">@color/dark_black</item>
+        <item name="android:windowBackground">@color/dark_black</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -20,6 +20,8 @@
         <item name="colorOnSecondary">@color/black</item>
 
         <item name="android:statusBarColor">@color/dark_black</item>
+        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:windowDisablePreview">true</item>
     </style>
 
     <style name="SpinnerDivideStyle" parent="android:style/Widget.ListView.DropDown">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -21,6 +21,9 @@
 
         <item name="android:statusBarColor">@color/dark_black</item>
         <item name="android:windowBackground">@color/dark_black</item>
+    </style>
+
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
         <item name="android:windowDisablePreview">true</item>
     </style>
 


### PR DESCRIPTION
# PR 내용
1. Android 12 이상에서 시스템 SplashScreen 배경을 앱 첫 화면과 동일한 `dark_black`으로 설정하고, 투명 아이콘을 적용해 스플래시 화면 노출감을 최소화
2. Android 12 미만에서는 `windowDisablePreview`를 적용해 별도 시작 preview 화면이 보이지 않도록 조정
3. 더 이상 사용하지 않는 `SplashActivity`와 `activity_splash.xml`을 제거해 앱 시작 진입점을 `MainActivity`로 명확히 정리
4. 투명한 스플래시 아이콘 `ic_splash_transparent.xml`을 추가