### PR TITLE
[ UI ] 플레이어 재생 시간 흔들림 현상 개선 및 실시간 정확도 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -452,9 +452,14 @@ class PlayerFragment : Fragment() {
                 binding.albumBackground.setBackgroundResource(R.color.dark_black)
 
                 updatePlayerView(playerModel.currentMusic)
+                binding.root.removeCallbacks(updateSeekRunnable)
+                updateSeekUi(duration = 0L, position = 0L)
 
                 // 트랙 전환 시 제목/아티스트/앨범 아트, 재생/일시정지 아이콘 동기화
                 syncPlayerUi()
+                if (player.isPlaying) {
+                    binding.root.postDelayed(updateSeekRunnable, SEEK_UPDATE_AFTER_TRANSITION_MS)
+                }
             }
 
             // 재생, 재생 완료, 버퍼링 상태 ...
@@ -532,26 +537,40 @@ class PlayerFragment : Fragment() {
         view.removeCallbacks(updateSeekRunnable)
 
         if (player.isPlaying) {
-            view.postDelayed(updateSeekRunnable, 1000L)
+            val currentPositionMs = position.coerceAtLeast(0L)
+            val delay = (ONE_SECOND_MS - (currentPositionMs % ONE_SECOND_MS) + SEEK_UPDATE_BOUNDARY_OFFSET_MS)
+                .coerceIn(MIN_SEEK_UPDATE_DELAY_MS, MAX_SEEK_UPDATE_DELAY_MS) // 다음에 updateSeek()를 다시 실행하는데 걸리는 시간 (ms)
+            view.postDelayed(updateSeekRunnable, delay)
         }
     }
 
     private fun updateSeekUi(duration: Long, position: Long) {
-        binding.sbPlayer.max = (duration / 1000).toInt() // 총 길이를 설정. 1000으로 나눠 작게
-        binding.sbPlayer.progress = (position / 1000).toInt() // 동일하게 1000으로 나눠 작게
+        // 재생 시작 직전, 트랙 전환 중에 들어올 수 있는 음수 값을 UI 계산 전에 보정
+        val durationMs = duration.coerceAtLeast(0L)
+        val positionMs = position.coerceAtLeast(0L)
+
+        // 초 경계 근처에서 시간 텍스트가 늦게 바뀌는 느낌을 줄이기 위한 표시용 위치
+        val displayPositionMs = if (durationMs > 0L) {
+            (positionMs + POSITION_DISPLAY_OFFSET_MS).coerceAtMost(durationMs)
+        } else {
+            positionMs
+        }
+
+        binding.sbPlayer.max = (durationMs / ONE_SECOND_MS).toInt() // 총 길이를 설정. 1000으로 나눠 작게
+        binding.sbPlayer.progress = (positionMs / ONE_SECOND_MS).toInt() // 동일하게 1000으로 나눠 작게
 
         binding.tvCurrentPlayTime.text = String.format(
             Locale.KOREA,
             "%02d:%02d",
-            TimeUnit.MINUTES.convert(position, TimeUnit.MILLISECONDS), // 현재 분
-            (position / 1000) % 60 // 분 단위를 제외한 현재 초
+            TimeUnit.MINUTES.convert(displayPositionMs, TimeUnit.MILLISECONDS), // 현재 분
+            (displayPositionMs / ONE_SECOND_MS) % 60 // 분 단위를 제외한 현재 초
         )
 
         binding.tvTotalTime.text = String.format(
             Locale.KOREA,
             "%02d:%02d",
-            TimeUnit.MINUTES.convert(duration, TimeUnit.MILLISECONDS), // 전체 분
-            (duration / 1000) % 60 // 분 단위를 제외한 초
+            TimeUnit.MINUTES.convert(durationMs, TimeUnit.MILLISECONDS), // 전체 분
+            (durationMs / ONE_SECOND_MS) % 60 // 분 단위를 제외한 초
         )
     }
 
@@ -1057,6 +1076,22 @@ class PlayerFragment : Fragment() {
     companion object {
         const val TAG = "PlayerFragment"
         const val EXTRA_MUSIC_FILE_ID: String = "id"
+
+        // 재생 시간 계산의 기본 단위
+        private const val ONE_SECOND_MS = 1_000L
+
+        // 시간 텍스트 표시를 초 경계에 더 가깝게 맞추기 위한 보정값
+        private const val POSITION_DISPLAY_OFFSET_MS = 80L
+
+        // 다음 초가 지난 직후 UI를 갱신하기 위한 지연값
+        private const val SEEK_UPDATE_BOUNDARY_OFFSET_MS = 50L
+
+        // 다음 갱신이 너무 자주 돌거나 1초 넘게 밀리지 않도록 제한하는 범위
+        private const val MIN_SEEK_UPDATE_DELAY_MS = 100L // 아무리 빨라도
+        private const val MAX_SEEK_UPDATE_DELAY_MS = 1_000L // 아무리 늦어도
+
+        // 자동 다음 곡 전환 직후 새 트랙 position을 다시 읽기 전까지 기다리는 시간
+        private const val SEEK_UPDATE_AFTER_TRANSITION_MS = 100L
 
         fun newInstance(musicId: String): PlayerFragment =
             PlayerFragment().apply {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -453,7 +453,7 @@ class PlayerFragment : Fragment() {
 
                 updatePlayerView(playerModel.currentMusic)
                 binding.root.removeCallbacks(updateSeekRunnable)
-                updateSeekUi(duration = 0L, position = 0L)
+                updatePlaybackProgressUi(duration = 0L, position = 0L)
 
                 // 트랙 전환 시 제목/아티스트/앨범 아트, 재생/일시정지 아이콘 동기화
                 syncPlayerUi()
@@ -527,7 +527,7 @@ class PlayerFragment : Fragment() {
         val duration = if (player.duration >= 0) player.duration else 0 // 전체 음악 길이
         val position = player.currentPosition
 
-        updateSeekUi(duration, position)
+        updatePlaybackProgressUi(duration, position)
 
         if (player.isPlaying) {
             savePlaybackState(immediate = false)
@@ -544,7 +544,7 @@ class PlayerFragment : Fragment() {
         }
     }
 
-    private fun updateSeekUi(duration: Long, position: Long) {
+    private fun updatePlaybackProgressUi(duration: Long, position: Long) {
         // 재생 시작 직전, 트랙 전환 중에 들어올 수 있는 음수 값을 UI 계산 전에 보정
         val durationMs = duration.coerceAtLeast(0L)
         val positionMs = position.coerceAtLeast(0L)

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -539,7 +539,7 @@ class PlayerFragment : Fragment() {
         if (player.isPlaying) {
             val currentPositionMs = position.coerceAtLeast(0L)
             val delay = (ONE_SECOND_MS - (currentPositionMs % ONE_SECOND_MS) + SEEK_UPDATE_BOUNDARY_OFFSET_MS)
-                .coerceIn(MIN_SEEK_UPDATE_DELAY_MS, MAX_SEEK_UPDATE_DELAY_MS) // 다음에 updateSeek()를 다시 실행하는데 걸리는 시간 (ms)
+                .coerceIn(MIN_SEEK_UPDATE_DELAY_MS, MAX_SEEK_UPDATE_DELAY_MS) // 다음에 updatePlaybackProgress()를 다시 실행하는데 걸리는 시간 (ms)
             view.postDelayed(updateSeekRunnable, delay)
         }
     }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -101,7 +101,7 @@ class PlayerFragment : Fragment() {
         get() = requireArguments().getString(EXTRA_MUSIC_FILE_ID).orEmpty()
 
     private val updateSeekRunnable = Runnable {
-        updateSeek()
+        updatePlaybackProgress()
     }
 
     private val updateBluetoothRunnable = Runnable {
@@ -399,7 +399,7 @@ class PlayerFragment : Fragment() {
             )
         )
         updatePlayerView(playerModel.currentMusic)
-        updateSeek()
+        updatePlaybackProgress()
         syncPlayerUi()
 
         return true
@@ -466,7 +466,7 @@ class PlayerFragment : Fragment() {
             override fun onPlaybackStateChanged(state: Int) {
                 super.onPlaybackStateChanged(state)
 
-                updateSeek()
+                updatePlaybackProgress()
 
                 // 재생 반복 해제 모드 & 마지막 트랙 재생이 끝났을 때 -> 첫번째 트랙으로 이동 & 일시정지 상태
                 if (player.repeatMode == Player.REPEAT_MODE_OFF &&
@@ -512,7 +512,7 @@ class PlayerFragment : Fragment() {
 
         binding.root.removeCallbacks(updateSeekRunnable)
 
-        updateSeek() // 즉시 1회 갱신하고, 내부에서 다음 주기를 예약
+        updatePlaybackProgress() // 즉시 1회 갱신하고, 내부에서 다음 주기를 예약
     }
 
     private fun stopSeekUpdates() {
@@ -521,7 +521,7 @@ class PlayerFragment : Fragment() {
         binding.root.removeCallbacks(updateSeekRunnable)
     }
 
-    private fun updateSeek() {
+    private fun updatePlaybackProgress() {
         if (_binding == null) return
         val player = this.player
         val duration = if (player.duration >= 0) player.duration else 0 // 전체 음악 길이

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -195,7 +195,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_4"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Sub"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.PlayerTime"
             app:layout_constraintStart_toStartOf="@id/layoutVolume"
             app:layout_constraintTop_toBottomOf="@id/layoutVolume"
             tools:text="00:00" />
@@ -205,7 +205,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_4"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Sub"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.PlayerTime"
             app:layout_constraintEnd_toEndOf="@id/layoutVolume"
             app:layout_constraintTop_toBottomOf="@id/layoutVolume"
             tools:text="03:00" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -68,18 +68,13 @@
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="TextAppearance.ZiggyMusic.White.Sub.Bold" parent="TextAppearance.ZiggyMusic.White.Sub">
-        <item name="android:fontFamily">@font/pretendard_bold</item>
-        <item name="fontFamily">@font/pretendard_bold</item>
+    <style name="TextAppearance.ZiggyMusic.PlayerTime" parent="TextAppearance.ZiggyMusic.White.Sub">
+        <!-- 숫자 폭을 일정하게 값 변경 시 폭 흔들림 완화 -->
+        <item name="android:fontFeatureSettings">tnum</item>
     </style>
 
     <style name="TextAppearance.ZiggyMusic.LightGray.Sub" parent="TextAppearance.ZiggyMusic.Sub">
         <item name="android:textColor">@color/light_gray</item>
-    </style>
-
-    <style name="TextAppearance.ZiggyMusic.PlayerTime" parent="TextAppearance.ZiggyMusic.Caption">
-        <item name="android:fontFamily">@font/pretendard_bold</item>
-        <item name="fontFamily">@font/pretendard_bold</item>
     </style>
 
     <style name="TextAppearance.ZiggyMusic.Spatial.DeviceTitle" parent="TextAppearance.ZiggyMusic.Base">

--- a/app/src/main/res/xml/player_motion_scene.xml
+++ b/app/src/main/res/xml/player_motion_scene.xml
@@ -280,7 +280,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/space_4"
             android:layout_marginTop="@dimen/space_4"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption"
             motion:layout_constraintStart_toStartOf="@id/layoutVolume"
             motion:layout_constraintTop_toBottomOf="@id/layoutVolume" />
 
@@ -290,7 +289,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/space_4"
             android:layout_marginEnd="@dimen/space_4"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption"
             motion:layout_constraintEnd_toEndOf="@id/layoutVolume"
             motion:layout_constraintTop_toBottomOf="@id/layoutVolume" />
 


### PR DESCRIPTION
# PR 내용
재생 시간 표시 안정화
1. `styles.xml`에서 PlayTime에 `TextAppearance.ZiggyMusic.PlayerTime` style에 tnum을 추가하여 시간 변경 시 숫자 폭 변화로 인한 흔들림 현상 개선
2. `tvCurrentPlayTime`의 숫자 폭 흔들림을 줄이기 위해 시간 표시 전용 TextAppearance를 적용
3. 재생 시간 갱신을 다음 초 경계에 맞춰 예약하도록 개선 
4. 초 경계 근처에서 시간이 늦게 바뀌는 느낌을 줄이기 위해 표시용 position 보정값을 추가
5. 자동 다음 트랙 전환 시 이전 트랙의 마지막 시간이 잠깐 남지 않도록 시간 UI를 즉시 초기화