### PR TITLE
[ UI ] 플레이어 확장/축소 제스처 동작 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -166,7 +166,7 @@ class PlayerFragment : Fragment() {
     private fun initPlayerManager() {
         playerBottomSheetManager = PlayerBottomSheetManager(
             viewLifecycleOwner.lifecycle,
-            binding.constraintLayout,
+            binding.motionLayout,
             object : BottomSheetCallback() {
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
                     when (newState) {
@@ -191,11 +191,11 @@ class PlayerFragment : Fragment() {
         )
 
         playerMotionManager = PlayerMotionManager(
-            binding.constraintLayout,
+            binding.motionLayout,
             playerBottomSheetManager
         )
 
-        binding.constraintLayout.post {
+        binding.motionLayout.post {
             if (_binding == null) return@post
             playerMotionManager.changeState(vm.motionState.value)
         }
@@ -211,7 +211,7 @@ class PlayerFragment : Fragment() {
                         startSeekUpdates()
 
                         // MotionLayout 배경 제거 -> containerPlayer 배경(그라데이션)이 보이도록 함
-                        binding.constraintLayout.background = null
+                        binding.motionLayout.background = null
 
                         binding.albumBackground.setBackgroundResource(R.color.dark_black)
 
@@ -226,7 +226,7 @@ class PlayerFragment : Fragment() {
                         }
                     } else {
                         // 플레이어가 닫히면(Collapsed) 투명해진 배경을 다시 원래 검은색으로 복구
-                        binding.constraintLayout.setBackgroundResource(R.color.dark_black)
+                        binding.motionLayout.setBackgroundResource(R.color.dark_black)
                         binding.albumBackground.setBackgroundResource(R.color.dark_black)
 
                         stopSeekUpdates()

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -153,12 +153,9 @@ class PlayerFragment : Fragment() {
 
     private fun initListeners() {
         binding.root.setOnClickListener {
-            val toggleState = when (vm.motionState.value) {
-                PlayerMotionManager.State.COLLAPSED -> PlayerMotionManager.State.EXPANDED
-                PlayerMotionManager.State.EXPANDED -> PlayerMotionManager.State.COLLAPSED
+            if (vm.motionState.value == PlayerMotionManager.State.COLLAPSED) {
+                vm.changeState(PlayerMotionManager.State.EXPANDED)
             }
-
-            vm.changeState(toggleState)
         }
 
         toggleVolumeIcon()
@@ -188,6 +185,7 @@ class PlayerFragment : Fragment() {
                 }
 
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                    playerMotionManager.updateProgress(slideOffset)
                 }
             }
         )

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerMotionManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerMotionManager.kt
@@ -14,17 +14,35 @@ class PlayerMotionManager(
     }
 
     fun changeState(state: State) {
+        if (isAtTargetState(state)) {
+            snapToState(state)
+            return
+        }
+
         when (state) {
             State.COLLAPSED -> collapse()
             State.EXPANDED -> expand()
         }
     }
 
+    fun updateProgress(slideOffset: Float) {
+        motionLayout.setTransition(R.id.collapsedToExpanded)
+        motionLayout.progress = slideOffset.coerceIn(0f, 1f)
+    }
+
+    // 애니메이션 없이 Motion 상태로 맞춘다
+    fun snapToState(state: State) {
+        motionLayout.setTransition(R.id.collapsedToExpanded)
+        motionLayout.progress = when (state) {
+            State.COLLAPSED -> COLLAPSED_PROGRESS
+            State.EXPANDED -> EXPANDED_PROGRESS
+        }
+    }
+
     private fun collapse() {
         motionLayout.doOnLayout {
-            motionLayout.setTransition(R.id.expandedToCollapsed)
-            motionLayout.progress = 0f
-            motionLayout.transitionToEnd()
+            motionLayout.setTransition(R.id.collapsedToExpanded)
+            motionLayout.transitionToStart()
         }
 
         bottomSheetManager.collapse()
@@ -33,10 +51,22 @@ class PlayerMotionManager(
     private fun expand() {
         motionLayout.doOnLayout {
             motionLayout.setTransition(R.id.collapsedToExpanded)
-            motionLayout.progress = 0f
             motionLayout.transitionToEnd()
         }
 
         bottomSheetManager.expand()
+    }
+
+    // progress가 거의 0 또는 1이면 이미 최종 상태로 보고 같은 전환을 다시 시작하지 않는다.
+    private fun isAtTargetState(state: State): Boolean =
+        when (state) {
+            State.COLLAPSED -> motionLayout.progress <= PROGRESS_EPSILON
+            State.EXPANDED -> motionLayout.progress >= EXPANDED_PROGRESS - PROGRESS_EPSILON
+        }
+
+    private companion object {
+        const val COLLAPSED_PROGRESS = 0f
+        const val EXPANDED_PROGRESS = 1f
+        const val PROGRESS_EPSILON = 0.01f // progress 비교용 작은 오차 허용값
     }
 }

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -11,7 +11,7 @@
     </data>
 
     <androidx.constraintlayout.motion.widget.MotionLayout
-        android:id="@+id/constraintLayout"
+        android:id="@+id/motionLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/dark_black"


### PR DESCRIPTION
# PR 내용
1. Collapsed 상태의 플레이어를 클릭하면 Expanded 상태로 전환되도록 유지
2. Expanded 상태에서 단순 클릭만으로 Collapsed 되는 동작 제거
3. BottomSheet 드래그 진행률을 MotionLayout progress와 동기화
4. 전환 완료 직후 같은 애니메이션이 다시 시작되지 않도록 최종 상태 판정 로직 추가