### PR TITLE
[ UI ] 메인 화면 Background UI 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -216,12 +217,12 @@ class MainActivity : AppCompatActivity(),
     }
 
     private fun initStatusBarColor() {
-        // statusBar 컬러를 toolBar 컬러와 동일하게 맞추기 위함
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) { // Android 11+
-            window.decorView.setOnApplyWindowInsetsListener { view, insets ->
+        val systemBarColor = ContextCompat.getColor(this, R.color.main_dark_gradient_start)
+        window.statusBarColor = systemBarColor
+        window.navigationBarColor = systemBarColor
 
-                insets
-            }
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            isAppearanceLightStatusBars = false
         }
     }
 
@@ -400,10 +401,16 @@ class MainActivity : AppCompatActivity(),
         }
 
         // 3. 배경색 및 Insets 처리
-        val defaultSystemBarColor = ContextCompat.getColor(this, R.color.dark_black)
-        window.statusBarColor = defaultSystemBarColor
-        window.decorView.setBackgroundColor(defaultSystemBarColor)
-        binding.containerPlayer.setBackgroundColor(defaultSystemBarColor)
+        val defaultSystemBarColor = ContextCompat.getColor(this, R.color.main_dark_gradient_start)
+        window.statusBarColor = if (isExpanded) Color.TRANSPARENT else defaultSystemBarColor
+        window.navigationBarColor = defaultSystemBarColor
+        binding.containerPlayer.setBackgroundColor(
+            if (isExpanded) {
+                ContextCompat.getColor(this, R.color.dark_black)
+            } else {
+                Color.TRANSPARENT
+            }
+        )
 
         if (isExpanded) {
             ViewCompat.setOnApplyWindowInsetsListener(binding.containerPlayer) { view, insets ->
@@ -433,5 +440,4 @@ class MainActivity : AppCompatActivity(),
             })
         }
     }
-
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/MusicAlbumArtGradientManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/MusicAlbumArtGradientManager.kt
@@ -1,7 +1,5 @@
 package com.hero.ziggymusic.view.main.player
 
-import android.animation.ArgbEvaluator
-import android.animation.ValueAnimator
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
@@ -15,7 +13,6 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.view.WindowManager
-import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.graphics.toColorInt
@@ -54,7 +51,7 @@ class MusicAlbumArtGradientManager(private val context: Context) {
                 albumBackground.background = null
                 activity.findViewById<View>(R.id.containerPlayer)?.crossfadeTo(gradientLayer)
                 activity.crossfadeWindowTo(gradientLayer)
-                activity.animateOpaqueStatusBarTo(topColor)
+                activity.makeStatusBarTransparent()
             }
         }
     }
@@ -79,11 +76,11 @@ class MusicAlbumArtGradientManager(private val context: Context) {
             if (animate) {
                 containerPlayer?.crossfadeTo(darkBackground)
                 activity.crossfadeWindowTo(darkBackground)
-                activity.animateOpaqueStatusBarTo(darkColor)
+                activity.makeStatusBarTransparent()
             } else {
                 containerPlayer?.background = darkBackground.newDrawableInstance()
                 activity.window.setBackgroundDrawable(darkBackground.newDrawableInstance())
-                activity.setOpaqueStatusBarColor(darkColor)
+                activity.makeStatusBarTransparent()
             }
         }
     }
@@ -131,26 +128,10 @@ class MusicAlbumArtGradientManager(private val context: Context) {
         )
     }
 
-    private fun Activity.animateOpaqueStatusBarTo(color: Int) {
-        prepareOpaqueStatusBar()
-        ValueAnimator.ofObject(ArgbEvaluator(), window.statusBarColor, color).apply {
-            duration = BACKGROUND_FADE_DURATION_MS.toLong()
-            interpolator = AccelerateDecelerateInterpolator()
-            addUpdateListener { animator ->
-                window.statusBarColor = animator.animatedValue as Int
-            }
-            start()
-        }
-    }
-
-    private fun Activity.setOpaqueStatusBarColor(color: Int) {
-        prepareOpaqueStatusBar()
-        window.statusBarColor = color
-    }
-
-    private fun Activity.prepareOpaqueStatusBar() {
+    private fun Activity.makeStatusBarTransparent() {
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        window.statusBarColor = Color.TRANSPARENT
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isStatusBarContrastEnforced = false
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -247,8 +247,8 @@ class PlayerFragment : Fragment() {
                             albumGradientManager?.resetToDarkBackground(binding.albumBackground)
                         }
                     } else {
-                        // 플레이어가 접히면 투명해진 배경을 기본 검은색으로 복구
-                        binding.motionLayout.setBackgroundResource(R.color.dark_black)
+                        // 플레이어가 접히면 root gradient 위에 반투명 surface로 표시한다.
+                        binding.motionLayout.setBackgroundResource(R.color.player_collapsed_scrim)
                         binding.albumBackground.setBackgroundResource(R.color.dark_black)
 
                         stopSeekUpdates()
@@ -634,13 +634,13 @@ class PlayerFragment : Fragment() {
         }
         lastRenderedMusicId = musicModel.id
 
-        binding.tvSongTitle.text = musicModel.title.orEmpty()
-        binding.tvSongArtist.text = musicModel.artist.orEmpty()
-        binding.tvSongAlbum.text = musicModel.album.orEmpty()
+        binding.tvSongTitle.text = musicModel?.title.orEmpty()
+        binding.tvSongArtist.text = musicModel?.artist.orEmpty()
+        binding.tvSongAlbum.text = musicModel?.album.orEmpty()
         updatePlayerTextMarquee(vm.motionState.value)
 
         latestAlbumBitmap = null
-        // Decode at expanded size so startup/collapsed loads are not stretched later.
+        // Expanded 상태에서 Decode -> Startup/Collapsed 상태에서 로드할 때 나중에 stretch되지 않게 함
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.album_art_size_expanded)
         val albumArtCornerRadius = resources.getDimensionPixelSize(R.dimen.album_art_corner_radius)
 

--- a/app/src/main/res/drawable/bg_main_dark_gradient.xml
+++ b/app/src/main/res/drawable/bg_main_dark_gradient.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:centerColor="@color/main_dark_gradient_center"
+        android:endColor="@color/main_dark_gradient_end"
+        android:startColor="@color/main_dark_gradient_start" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/dark_black"
+    android:background="@drawable/bg_main_dark_gradient"
     android:fitsSystemWindows="true"
     tools:context=".view.main.MainActivity">
 
@@ -12,7 +12,7 @@
         android:id="@+id/toolbarMain"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/dark_black"
+        android:background="@color/transparent"
         app:contentInsetStart="0dp"
         app:layout_constraintTop_toTopOf="parent">
 
@@ -63,13 +63,14 @@
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize"
         android:layout_marginBottom="@dimen/player_peek_height"
-        android:background="@drawable/main_background" />
+        android:background="@color/transparent" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/containerPlayer"
         style="@style/PlayerBottomSheet"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/transparent"
         app:behavior_peekHeight="@dimen/player_peek_height"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
 
@@ -78,7 +79,8 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_nav_height"
         android:layout_gravity="bottom"
-        app:backgroundTint="@color/dark_black"
+        android:background="@color/bottom_nav_scrim"
+        app:backgroundTint="@color/bottom_nav_scrim"
         app:itemIconTint="@color/bottom_nav_item_color"
         app:itemTextAppearanceActive="@style/TextAppearance.ZiggyMusic.BottomNavigation"
         app:itemTextAppearanceInactive="@style/TextAppearance.ZiggyMusic.BottomNavigation"

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -5,7 +5,7 @@
     android:id="@+id/motionLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/dark_black"
+    android:background="@color/player_collapsed_scrim"
     app:layoutDescription="@xml/player_motion_scene">
 
         <View
@@ -26,14 +26,14 @@
             android:layout_height="?attr/actionBarSize"
             app:layout_constraintTop_toTopOf="parent">
 
-            <ImageView
-                android:id="@+id/ivDragHandle"
-                android:layout_width="42dp"
-                android:layout_height="48dp"
-                android:layout_gravity="top|center_horizontal"
-                android:paddingTop="@dimen/space_14"
-                android:src="@drawable/ic_drag_handle"
-                android:contentDescription="@null" />
+                <ImageView
+                    android:id="@+id/ivDragHandle"
+                    android:layout_width="42dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="top|center_horizontal"
+                    android:paddingTop="@dimen/space_14"
+                    android:src="@drawable/ic_drag_handle"
+                    android:contentDescription="@null" />
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -26,14 +26,14 @@
             android:layout_height="?attr/actionBarSize"
             app:layout_constraintTop_toTopOf="parent">
 
-                <ImageView
-                    android:id="@+id/ivDragHandle"
-                    android:layout_width="42dp"
-                    android:layout_height="48dp"
-                    android:layout_gravity="top|center_horizontal"
-                    android:paddingTop="@dimen/space_14"
-                    android:src="@drawable/ic_drag_handle"
-                    android:contentDescription="@null" />
+            <ImageView
+                android:id="@+id/ivDragHandle"
+                android:layout_width="42dp"
+                android:layout_height="48dp"
+                android:layout_gravity="top|center_horizontal"
+                android:paddingTop="@dimen/space_14"
+                android:src="@drawable/ic_drag_handle"
+                android:contentDescription="@null" />
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/item_music_list.xml
+++ b/app/src/main/res/layout/item_music_list.xml
@@ -5,7 +5,7 @@
     android:id="@+id/mcvMusicList"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardBackgroundColor="@color/normal_gray"
+    app:cardBackgroundColor="@color/transparent"
     app:cardCornerRadius="@dimen/album_art_corner_radius"
     app:cardElevation="0dp"
     app:cardUseCompatPadding="false"

--- a/app/src/main/res/layout/item_my_playlist.xml
+++ b/app/src/main/res/layout/item_my_playlist.xml
@@ -5,7 +5,7 @@
     android:id="@+id/mcvMusicList"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardBackgroundColor="@color/normal_gray"
+    app:cardBackgroundColor="@color/transparent"
     app:cardCornerRadius="@dimen/album_art_corner_radius"
     app:cardElevation="0dp"
     app:cardUseCompatPadding="false"

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -19,12 +19,13 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
 
-        <item name="android:statusBarColor">@color/dark_black</item>
-        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:statusBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:navigationBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
     <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
-        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
+        <item name="android:windowSplashScreenBackground">@color/main_dark_gradient_start</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -17,8 +17,9 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
 
-        <item name="android:statusBarColor">@color/dark_black</item>
-        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:statusBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:navigationBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
     <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -19,12 +19,13 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
 
-        <item name="android:statusBarColor">@color/dark_black</item>
-        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:statusBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:navigationBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
     <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
-        <item name="android:windowSplashScreenBackground">@color/dark_black</item>
+        <item name="android:windowSplashScreenBackground">@color/main_dark_gradient_start</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/ic_splash_transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,11 @@
     <color name="white">#ffffff</color>
     <color name="black">#000000</color>
     <color name="dark_black">#201F1F</color>
+    <color name="main_dark_gradient_start">#050607</color>
+    <color name="main_dark_gradient_center">#101214</color>
+    <color name="main_dark_gradient_end">#1A1B1E</color>
+    <color name="bottom_nav_scrim">#CC101214</color>
+    <color name="player_collapsed_scrim">#E6101214</color>
     <color name="dark_gray">#535353</color>
     <color name="gray_333">#333333</color>
     <color name="background1">#475263</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -154,9 +154,11 @@
         <item name="android:elevation">0dp</item>
     </style>
 
-    <style name="roundedCorners">
+    <style name="ShapeAppearance.ZiggyMusic" parent="ShapeAppearance.MaterialComponents.SmallComponent" />
+
+    <style name="ShapeAppearance.ZiggyMusic.AlbumArt" parent="ShapeAppearance.ZiggyMusic">
         <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">@dimen/card_corner_radius</item>
+        <item name="cornerSize">@dimen/album_art_corner_radius</item>
     </style>
 
     <style name="Custom_Spinner_Item_Style" parent="Widget.AppCompat.DropDownItem.Spinner">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -17,8 +17,9 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
 
-        <item name="android:statusBarColor">@color/dark_black</item>
-        <item name="android:windowBackground">@color/dark_black</item>
+        <item name="android:statusBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:navigationBarColor">@color/main_dark_gradient_start</item>
+        <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
     <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">


### PR DESCRIPTION
# PR 내용
1. 메인 화면에서 toolbar와 recyclerview의 배경색을 dark gradient로 통일
  - bg_main_dark_gradient.xml 생성 및 적용
  - Status Bar 색상 처리 로직 개선
2. colors.xml에 배경용 그라데이션 색상(`main_dark_gradient_start`, `center`, `end`) 정의, 하단 네비게이션 바 및 플레이어 UI용 스크림(`bottom_nav_scrim`, `player_collapsed_scrim`) 색상 정의
3. 음악 아이템의 배경색에 transparent 적용, 플레이어의 배경색에 `player_collapsed_scrim` 적용
4. MusicAlbumArtGradientManager에서 Status Bar 투명화 및 화면 전환에 따라 색상이 정상 적용되도록 로직 개선
5. `roundedCorners` 스타일을 `ShapeAppearance.ZiggyMusic.AlbumArt`로 변경