### PR TITLE
[ UI ] 음악 아이템 아티스트 텍스트 스타일 개선

### DIFF
--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -370,7 +370,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="@dimen/space_xxxl"
                         android:text="@string/head_tracking"
-                        android:textAppearance="@style/TextAppearance.ZiggyMusic.LightGray.Sub"
+                        android:textAppearance="@style/TextAppearance.ZiggyMusic.NormalGray.Sub"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_music_list.xml
+++ b/app/src/main/res/layout/item_music_list.xml
@@ -62,7 +62,7 @@
             android:layout_marginTop="@dimen/space_sm"
             android:ellipsize="end"
             android:maxLines="1"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Sub"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.NormalGray.Sub"
             app:layout_constraintEnd_toStartOf="@id/ivMusicOptionMenu"
             app:layout_constraintStart_toEndOf="@id/ivAlbum"
             app:layout_constraintTop_toBottomOf="@id/tvSongTitle"

--- a/app/src/main/res/layout/item_my_playlist.xml
+++ b/app/src/main/res/layout/item_my_playlist.xml
@@ -62,7 +62,7 @@
             android:layout_marginTop="@dimen/space_sm"
             android:ellipsize="end"
             android:maxLines="1"
-            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Sub"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.NormalGray.Sub"
             app:layout_constraintEnd_toStartOf="@id/ivMusicOptionMenu"
             app:layout_constraintStart_toEndOf="@id/ivAlbum"
             app:layout_constraintTop_toBottomOf="@id/tvSongTitle"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,8 +89,8 @@
         <item name="android:fontFeatureSettings">tnum</item>
     </style>
 
-    <style name="TextAppearance.ZiggyMusic.LightGray.Sub" parent="TextAppearance.ZiggyMusic.Sub">
-        <item name="android:textColor">@color/light_gray</item>
+    <style name="TextAppearance.ZiggyMusic.NormalGray.Sub" parent="TextAppearance.ZiggyMusic.Sub">
+        <item name="android:textColor">@color/normal_gray</item>
     </style>
 
     <style name="TextAppearance.ZiggyMusic.Setting.Spinner" parent="TextAppearance.ZiggyMusic.White.Caption">


### PR DESCRIPTION
# PR 내용
- `styles.xml`에서 `LightGray.Sub` 스타일을 `NormalGray.Sub`로 변경
  - 음악 목록 및 나의 플레이리스트 아이템 아티스트 텍스트 스타일 수정
  - Head Tracking의 텍스트 스타일 수정