### PR TITLE
[ Fix ] 뒤로 가기 버그 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -214,13 +214,6 @@ class MainActivity : AppCompatActivity(),
         return true
     }
 
-    private fun getCurrentMainTitle(): MainTitle {
-        return when (binding.bottomNavMain.selectedItemId) {
-            R.id.menu_favorites -> MainTitle.Favorites
-            else -> MainTitle.MusicList
-        }
-    }
-
     private fun startMusicServiceIfNotificationAllowed() {
         if (!hasNotificationPermission()) return
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -120,8 +120,10 @@ class MainActivity : AppCompatActivity(),
         }
 
         supportFragmentManager.addOnBackStackChangedListener {
-            if (supportFragmentManager.backStackEntryCount == 0) {
-                vm.setTitle(getCurrentMainTitle())
+            when (supportFragmentManager.findFragmentById(binding.fcvMain.id)) {
+                is MusicListFragment -> vm.setTitle(MainTitle.MusicList)
+                is FavoritesFragment -> vm.setTitle(MainTitle.Favorites)
+                is SettingFragment -> vm.setTitle(MainTitle.Setting)
             }
         }
 


### PR DESCRIPTION
# PR 내용
- 일부 기기에서 뒤로 가기해서 타이틀과 버튼이 바뀌지 않는 버그 수정 
  - `addOnBackStackChangedListener` 내에서 `findFragmentById`를 사용하여 현재 표시 중인 Fragment를 직접 식별하도록 변경
  - 미사용 메서드인 `getCurrentMainTitle()`을 제거하여 타이틀 동기화 방식 정교화