### PR TITLE
[ Feature ] 음악 옵션 메뉴 클릭 영역 확장

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/ext/ViewExt.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ext/ViewExt.kt
@@ -1,0 +1,24 @@
+package com.hero.ziggymusic.ext
+
+import android.graphics.Rect
+import android.view.TouchDelegate
+import android.view.View
+import kotlin.math.roundToInt
+
+fun View.expandTouchArea(minTouchTargetDp: Int = 48) {
+    val parentView = parent as? View ?: return
+    parentView.post {
+        val minTouchTargetPx = (minTouchTargetDp * resources.displayMetrics.density).roundToInt()
+        val widthExpansion = (minTouchTargetPx - width).coerceAtLeast(0)
+        val heightExpansion = (minTouchTargetPx - height).coerceAtLeast(0)
+        val touchBounds = Rect()
+
+        getHitRect(touchBounds)
+        touchBounds.left -= widthExpansion / 2
+        touchBounds.right += widthExpansion - widthExpansion / 2
+        touchBounds.top -= heightExpansion / 2
+        touchBounds.bottom += heightExpansion - heightExpansion / 2
+
+        parentView.touchDelegate = TouchDelegate(touchBounds, this)
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/view/main/favorites/FavoritesAdapter.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/favorites/FavoritesAdapter.kt
@@ -12,6 +12,7 @@ import com.bumptech.glide.Glide
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.databinding.ItemFavoritesBinding
+import com.hero.ziggymusic.ext.expandTouchArea
 import com.hero.ziggymusic.ext.toDurationText
 
 class FavoritesAdapter(
@@ -60,6 +61,7 @@ class FavoritesAdapter(
                 Log.d("onItemClick", "MusicModel: $favoriteItem, ${favoriteItem.id}")
             }
 
+            binding.ivMusicOptionMenu.expandTouchArea()
             binding.ivMusicOptionMenu.setOnClickListener { view ->
                 onOptionClick(favoriteItem, view)
             }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListAdapter.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListAdapter.kt
@@ -11,6 +11,7 @@ import com.bumptech.glide.Glide
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.databinding.ItemMusicListBinding
+import com.hero.ziggymusic.ext.expandTouchArea
 import com.hero.ziggymusic.ext.toDurationText
 
 class MusicListAdapter(
@@ -59,6 +60,7 @@ class MusicListAdapter(
                 onItemClick(musicItem)
             }
 
+            binding.ivMusicOptionMenu.expandTouchArea()
             binding.ivMusicOptionMenu.setOnClickListener { view ->
                 onOptionClick(musicItem, view)
             }


### PR DESCRIPTION
# PR 내용
1. `View.expandTouchArea` 확장 함수 추가
  - 부족한 영역만큼 상하좌우 터치 범위를 계산하여 적용하는 로직 구현
  - 뷰의 터치 가능 영역을 확장
2. `MusicListAdapter` 및 `FavoritesAdapter`의 각 아이템 옵션 메뉴 아이콘에 `expandTouchArea()` 확장 함수를 적용하여 메뉴 아이콘의 클릭 편의성을 향상