### PR TITLE
[ Feature ] 메인 화면 툴바 아이콘 편집 및 클릭 영역 보완

### DIFF
--- a/app/src/main/res/drawable/ic_left_arrow.xml
+++ b/app/src/main/res/drawable/ic_left_arrow.xml
@@ -7,10 +7,11 @@
     <clip-path
         android:pathData="M0,0h24v24h-24z"/>
     <path
-        android:pathData="M15,5L8.141,11.859C8.063,11.937 8.063,12.063 8.141,12.141L15,19"
-        android:strokeWidth="2"
+        android:pathData="M16.5,4.75L8.5,12L16.5,19.25"
+        android:strokeWidth="2.5"
         android:fillColor="#00000000"
         android:strokeColor="#ffffff"
+        android:strokeLineJoin="round"
         android:strokeLineCap="round"/>
   </group>
 </vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,15 +22,16 @@
 
             <ImageView
                 android:id="@+id/ivBack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/space_xl"
+                android:layout_width="@dimen/toolbar_icon_touch_size"
+                android:layout_height="@dimen/toolbar_icon_touch_size"
+                android:layout_marginStart="@dimen/space_sm"
+                android:padding="@dimen/toolbar_icon_padding"
                 android:src="@drawable/ic_left_arrow"
+                android:scaleType="fitCenter"
                 android:visibility="invisible"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="TouchTargetSizeCheck" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/tvMainTitle"
@@ -45,10 +46,12 @@
 
             <ImageView
                 android:id="@+id/ivSetting"
-                android:layout_width="@dimen/icon_md"
-                android:layout_height="@dimen/icon_md"
-                android:layout_marginEnd="@dimen/space_xl"
+                android:layout_width="@dimen/toolbar_icon_touch_size"
+                android:layout_height="@dimen/toolbar_icon_touch_size"
+                android:layout_marginEnd="@dimen/space_sm"
+                android:padding="@dimen/toolbar_icon_padding"
                 android:src="@drawable/ic_setting"
+                android:scaleType="fitCenter"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">14dp</dimen>
     <dimen name="icon_md">22dp</dimen>
     <dimen name="icon_lg">30dp</dimen>
+    <dimen name="toolbar_icon_touch_size">48dp</dimen>
+    <dimen name="toolbar_icon_padding">14dp</dimen>
     <dimen name="music_search_horizontal_inset_start">10dp</dimen>
     <dimen name="music_search_horizontal_inset_end">13dp</dimen>
     <dimen name="music_search_container_height">50dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">16dp</dimen>
     <dimen name="icon_md">24dp</dimen>
     <dimen name="icon_lg">32dp</dimen>
+    <dimen name="toolbar_icon_touch_size">48dp</dimen>
+    <dimen name="toolbar_icon_padding">14dp</dimen>
     <dimen name="music_search_horizontal_inset_start">15dp</dimen>
     <dimen name="music_search_horizontal_inset_end">18dp</dimen>
     <dimen name="music_search_container_height">52dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">18dp</dimen>
     <dimen name="icon_md">24dp</dimen>
     <dimen name="icon_lg">34dp</dimen>
+    <dimen name="toolbar_icon_touch_size">50dp</dimen>
+    <dimen name="toolbar_icon_padding">14dp</dimen>
     <dimen name="music_search_horizontal_inset_start">20dp</dimen>
     <dimen name="music_search_horizontal_inset_end">24dp</dimen>
     <dimen name="music_search_container_height">56dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">18dp</dimen>
     <dimen name="icon_md">26dp</dimen>
     <dimen name="icon_lg">34dp</dimen>
+    <dimen name="toolbar_icon_touch_size">52dp</dimen>
+    <dimen name="toolbar_icon_padding">15dp</dimen>
     <dimen name="music_search_horizontal_inset_start">25dp</dimen>
     <dimen name="music_search_horizontal_inset_end">30dp</dimen>
     <dimen name="music_search_container_height">60dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">20dp</dimen>
     <dimen name="icon_md">28dp</dimen>
     <dimen name="icon_lg">36dp</dimen>
+    <dimen name="toolbar_icon_touch_size">56dp</dimen>
+    <dimen name="toolbar_icon_padding">15dp</dimen>
     <dimen name="music_search_horizontal_inset_start">30dp</dimen>
     <dimen name="music_search_horizontal_inset_end">36dp</dimen>
     <dimen name="music_search_container_height">68dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">20dp</dimen>
     <dimen name="icon_md">30dp</dimen>
     <dimen name="icon_lg">38dp</dimen>
+    <dimen name="toolbar_icon_touch_size">62dp</dimen>
+    <dimen name="toolbar_icon_padding">16dp</dimen>
     <dimen name="music_search_horizontal_inset_start">35dp</dimen>
     <dimen name="music_search_horizontal_inset_end">42dp</dimen>
     <dimen name="music_search_container_height">68dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="icon_sm">16dp</dimen>
     <dimen name="icon_md">24dp</dimen>
     <dimen name="icon_lg">32dp</dimen>
+    <dimen name="toolbar_icon_touch_size">48dp</dimen>
+    <dimen name="toolbar_icon_padding">14dp</dimen>
     <dimen name="music_search_horizontal_inset_start">15dp</dimen>
     <dimen name="music_search_horizontal_inset_end">18dp</dimen>
     <dimen name="music_search_container_height">52dp</dimen>


### PR DESCRIPTION
# PR 내용
1. 뒤로 가기 아이콘 편집
  - 굵기 수정, 선 연결부 스타일에 `round` 속성 추가
2. toolbarMain 아이콘 터치 영역 및 마진 수정
- `toolbar_icon_touch_size` 및 `toolbar_icon_padding` 디멘션 정의
- `sw320dp`부터 `sw720dp`까지 화면 너비별 가변 리소스를 추가하여 기기 크기에 최적화된 터치 타겟 확보