### PR TITLE
[ UI ] 앨범 아트 모서리 곡률 보완 및 플레이스홀더 앨범 아트 로드 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -635,9 +635,9 @@ class PlayerFragment : Fragment() {
         }
         lastRenderedMusicId = musicModel.id
 
-        binding.tvSongTitle.text = musicModel?.title.orEmpty()
-        binding.tvSongArtist.text = musicModel?.artist.orEmpty()
-        binding.tvSongAlbum.text = musicModel?.album.orEmpty()
+        binding.tvSongTitle.text = musicModel.title.orEmpty()
+        binding.tvSongArtist.text = musicModel.artist.orEmpty()
+        binding.tvSongAlbum.text = musicModel.album.orEmpty()
         updatePlayerTextMarquee(vm.motionState.value)
 
         latestAlbumBitmap = null

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -185,6 +185,10 @@ class PlayerFragment : Fragment() {
                         BottomSheetBehavior.STATE_HIDDEN -> {
                             playerBottomSheetManager.collapse()
                         }
+
+                        BottomSheetBehavior.STATE_DRAGGING -> {}
+                        BottomSheetBehavior.STATE_HALF_EXPANDED -> {}
+                        BottomSheetBehavior.STATE_SETTLING -> {}
                     }
                 }
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -32,7 +32,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.ShuffleOrder
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import com.hero.ziggymusic.R
@@ -197,7 +196,8 @@ class PlayerFragment : Fragment() {
 
         playerMotionManager = PlayerMotionManager(
             binding.motionLayout,
-            playerBottomSheetManager
+            playerBottomSheetManager,
+            onProgressChanged = ::updateAlbumArtCornerRadius
         )
 
         binding.motionLayout.post {
@@ -641,17 +641,19 @@ class PlayerFragment : Fragment() {
         updatePlayerTextMarquee(vm.motionState.value)
 
         latestAlbumBitmap = null
+
         // Expanded 상태에서 Decode -> Startup/Collapsed 상태에서 로드할 때 나중에 stretch되지 않게 함
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.album_art_size_expanded)
-        val albumArtCornerRadius = resources.getDimensionPixelSize(R.dimen.album_art_corner_radius)
+        val albumUri = musicModel.getAlbumUri()
 
         Glide.with(binding.ivAlbumArt.context)
             .asBitmap()
-            .load(musicModel.getAlbumUri())
+            .load(albumUri)
             .override(albumArtSize, albumArtSize)
+            .placeholder(binding.ivAlbumArt.drawable)
             .error(R.drawable.placeholder_album_art)
             .fallback(R.drawable.placeholder_album_art)
-            .transform(RoundedCorners(albumArtCornerRadius))
+            .dontAnimate()
             .listener(object : RequestListener<Bitmap> {
                 override fun onLoadFailed(
                     e: GlideException?,
@@ -666,7 +668,7 @@ class PlayerFragment : Fragment() {
                     if (vm.motionState.value == PlayerMotionManager.State.EXPANDED) {
                         albumGradientManager?.resetToDarkBackground(
                             binding.albumBackground,
-                            animate = true
+                            animate = false
                         )
                     } else {
                         binding.albumBackground.setBackgroundResource(R.color.dark_black)
@@ -711,6 +713,22 @@ class PlayerFragment : Fragment() {
         } else {
             binding.tvSongTitle.isSelected = false
         }
+    }
+
+    private fun updateAlbumArtCornerRadius(progress: Float) {
+        val expandedRadius = resources.getDimension(R.dimen.album_art_corner_radius)
+        val expandedSize = resources.getDimension(R.dimen.album_art_size_expanded)
+        val collapsedSize = resources.getDimension(R.dimen.album_art_size_collapsed)
+        val scaledCollapsedRadius = expandedRadius * (collapsedSize / expandedSize)
+        val minCollapsedRadius = expandedRadius * MIN_COLLAPSED_ALBUM_ART_RADIUS_RATIO
+        val collapsedRadius = max(scaledCollapsedRadius, minCollapsedRadius)
+        val coercedProgress = progress.coerceIn(0f, 1f)
+        val currentRadius = collapsedRadius + (expandedRadius - collapsedRadius) * coercedProgress
+
+        binding.ivAlbumArt.shapeAppearanceModel = binding.ivAlbumArt.shapeAppearanceModel
+            .toBuilder()
+            .setAllCornerSizes(currentRadius)
+            .build()
     }
 
     private fun savePlaybackState(immediate: Boolean = false) {
@@ -1012,6 +1030,8 @@ class PlayerFragment : Fragment() {
         private const val SEEK_UPDATE_AFTER_TRANSITION_MS = 100L
 
         private const val PLAYER_TEXT_MARQUEE_START_DELAY_MS = 700L
+
+        private const val MIN_COLLAPSED_ALBUM_ART_RADIUS_RATIO = 0.5f
 
         fun newInstance(musicId: String): PlayerFragment =
             PlayerFragment().apply {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -646,6 +646,25 @@ class PlayerFragment : Fragment() {
         val albumArtSize = resources.getDimensionPixelSize(R.dimen.album_art_size_expanded)
         val albumUri = musicModel.getAlbumUri()
 
+        if (albumUri == null) {
+            Glide.with(binding.ivAlbumArt.context).clear(binding.ivAlbumArt)
+            binding.ivAlbumArt.setImageResource(R.drawable.placeholder_album_art)
+
+            latestAlbumBitmap = null
+            resetVisualizerBarColor()
+
+            if (vm.motionState.value == PlayerMotionManager.State.EXPANDED) {
+                albumGradientManager?.resetToDarkBackground(
+                    binding.albumBackground,
+                    animate = false
+                )
+            } else {
+                binding.albumBackground.setBackgroundResource(R.color.dark_black)
+            }
+
+            return
+        }
+
         Glide.with(binding.ivAlbumArt.context)
             .asBitmap()
             .load(albumUri)

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerMotionManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerMotionManager.kt
@@ -6,7 +6,8 @@ import com.hero.ziggymusic.R
 
 class PlayerMotionManager(
     private val motionLayout: MotionLayout,
-    private val bottomSheetManager: PlayerBottomSheetManager
+    private val bottomSheetManager: PlayerBottomSheetManager,
+    private val onProgressChanged: (Float) -> Unit = {}
 ) {
     enum class State {
         COLLAPSED,
@@ -26,17 +27,21 @@ class PlayerMotionManager(
     }
 
     fun updateProgress(slideOffset: Float) {
+        val progress = slideOffset.coerceIn(0f, 1f)
         motionLayout.setTransition(R.id.collapsedToExpanded)
-        motionLayout.progress = slideOffset.coerceIn(0f, 1f)
+        motionLayout.progress = progress
+        onProgressChanged(progress)
     }
 
     // 애니메이션 없이 Motion 상태로 맞춘다
     fun snapToState(state: State) {
         motionLayout.setTransition(R.id.collapsedToExpanded)
-        motionLayout.progress = when (state) {
+        val progress = when (state) {
             State.COLLAPSED -> COLLAPSED_PROGRESS
             State.EXPANDED -> EXPANDED_PROGRESS
         }
+        motionLayout.progress = progress
+        onProgressChanged(progress)
     }
 
     private fun collapse() {

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -53,12 +53,14 @@
             app:layout_constraintTop_toBottomOf="@id/playerTopHandleContainer"
             tools:text="Out Of Time" />
 
-        <androidx.appcompat.widget.AppCompatImageView
+        <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/ivAlbumArt"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/space_xxxl"
             android:layout_marginTop="@dimen/space_xl"
+            android:scaleType="centerCrop"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.ZiggyMusic.AlbumArt"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tvSongTitle" />


### PR DESCRIPTION
# PR 내용
1. 플레이어의 Expanded/Collapsed 상태에 상관 없이 앨범아트의 모서리 곡률이 모두 동일하도록 개선
  - 앨범 아트가 없는 음원에 대해 로드되는 플레이스홀더 앨범 아트의 모서리 곡률도 통일하여 일관성 개선
2. 앨범 아트가 없는 음원에 대해 플레이스홀더 앨범 아트가 로드될 때 깜빡임 없이 로드되도록 개선
  - `PlayerMotionManager`에서 애니메이션 없이 Motion 상태로 맞추기 위해 `snapToState`에서 상태 전환 시에도 변경된 progress 값을 콜백으로 알리도록 로직 개선
3. `BottomSheetBehavior`의 `STATE_DRAGGING`, `STATE_HALF_EXPANDED`, `STATE_SETTLING` 상태를 `when` 블록에 명시적으로 추가
4. `musicModel`의 속성(`title`, `artist`, `album`)에 접근할 때 사용되던 불필요한 Safe Call(`?.`)을 제거