### PR TITLE
[ Feature ] 앱 실행 중 음원 추가/삭제 시 목록 및 재생 큐 동기화 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/database/local/MediaStoreMusicObserver.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MediaStoreMusicObserver.kt
@@ -1,0 +1,43 @@
+package com.hero.ziggymusic.database.local
+
+import android.content.Context
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+class MediaStoreMusicObserver @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    fun observeMusicChanges(): Flow<Unit> = callbackFlow {
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                trySend(Unit)
+            }
+
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                trySend(Unit)
+            }
+
+            override fun onChange(selfChange: Boolean, uris: MutableCollection<Uri>, flags: Int) {
+                trySend(Unit)
+            }
+        }
+
+        context.contentResolver.registerContentObserver(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            true,
+            observer
+        )
+
+        awaitClose {
+            context.contentResolver.unregisterContentObserver(observer)
+        }
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSource.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.hero.ziggymusic.database.local
 
 import androidx.lifecycle.LiveData
 import com.hero.ziggymusic.database.music.entity.MusicModel
+import kotlinx.coroutines.flow.Flow
 
 interface MusicLocalDataSource {
     suspend fun loadMusics()
@@ -13,6 +14,8 @@ interface MusicLocalDataSource {
     fun getAllMusic(): LiveData<List<MusicModel>>
 
     fun getFavorites(): LiveData<List<MusicModel>>
+
+    fun observeMusicChanges(): Flow<Unit>
 
     suspend fun addMusicToFavorites(musicModel: MusicModel)
 

--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
@@ -68,8 +68,14 @@ class MusicLocalDataSourceImpl @Inject constructor(
         }
 
         appMusicDatabase.withTransaction {
-            musicFileDao.clearAll()
             musicFileDao.insertAll(musicList)
+
+            val musicIdList = musicList.map { it.id }
+            if (musicIdList.isEmpty()) {
+                musicFileDao.clearAll()
+            } else {
+                musicFileDao.deleteFilesExcept(musicIdList)
+            }
         }
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
@@ -9,6 +9,7 @@ import com.hero.ziggymusic.database.music.dao.MusicFileDao
 import com.hero.ziggymusic.database.music.dao.FavoritesDao
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -17,6 +18,7 @@ class MusicLocalDataSourceImpl @Inject constructor(
     private val appMusicDatabase: AppMusicDatabase,
     private val musicFileDao: MusicFileDao,
     private val favoritesDao: FavoritesDao,
+    private val mediaStoreMusicObserver: MediaStoreMusicObserver,
 ) : MusicLocalDataSource {
     override suspend fun loadMusics() = withContext(Dispatchers.IO) {
         val musicListUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
@@ -86,6 +88,8 @@ class MusicLocalDataSourceImpl @Inject constructor(
     override fun getFavorites(): LiveData<List<MusicModel>> {
         return favoritesDao.getAllFiles()
     }
+
+    override fun observeMusicChanges(): Flow<Unit> = mediaStoreMusicObserver.observeMusicChanges()
 
     override suspend fun addMusicToFavorites(musicModel: MusicModel) {
         favoritesDao.insertMusic(musicModel)

--- a/app/src/main/java/com/hero/ziggymusic/database/music/dao/MusicFileDao.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/music/dao/MusicFileDao.kt
@@ -26,4 +26,7 @@ interface MusicFileDao {
 
     @Delete
     fun deleteMusic(musicModel: MusicModel)
+
+    @Query("DELETE FROM music_table WHERE id NOT IN (:musicIdList)")
+    suspend fun deleteFilesExcept(musicIdList: List<String>)
 }

--- a/app/src/main/java/com/hero/ziggymusic/database/music/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/music/repository/MusicRepositoryImpl.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import com.hero.ziggymusic.database.local.MusicLocalDataSource
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class MusicRepositoryImpl @Inject constructor(
@@ -28,6 +29,8 @@ class MusicRepositoryImpl @Inject constructor(
     override fun getFavorites(): LiveData<List<MusicModel>> {
         return musicLocalDataSource.getFavorites()
     }
+
+    override fun observeMusicChanges(): Flow<Unit> = musicLocalDataSource.observeMusicChanges()
 
     override suspend fun addMusicToFavorites(musicModel: MusicModel) {
         musicLocalDataSource.addMusicToFavorites(musicModel)

--- a/app/src/main/java/com/hero/ziggymusic/di/Injector.kt
+++ b/app/src/main/java/com/hero/ziggymusic/di/Injector.kt
@@ -3,6 +3,7 @@ package com.hero.ziggymusic.di
 import com.hero.ziggymusic.ZiggyMusicApp
 import com.hero.ziggymusic.database.AppMusicDatabase
 import com.hero.ziggymusic.database.AppFavoritesDatabase
+import com.hero.ziggymusic.database.local.MediaStoreMusicObserver
 import com.hero.ziggymusic.database.local.MusicLocalDataSourceImpl
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
 import com.hero.ziggymusic.database.music.repository.MusicRepositoryImpl
@@ -21,7 +22,8 @@ object Injector {
                 AppMusicDatabase.Companion.getInstance(ZiggyMusicApp.Companion.getInstance())
                     .musicFileDao(),
                 AppFavoritesDatabase.Companion.getInstance(ZiggyMusicApp.Companion.getInstance())
-                    .favoritesDao()
+                    .favoritesDao(),
+                MediaStoreMusicObserver(ZiggyMusicApp.getInstance())
             )
         )
 }

--- a/app/src/main/java/com/hero/ziggymusic/domain/music/repository/MusicRepository.kt
+++ b/app/src/main/java/com/hero/ziggymusic/domain/music/repository/MusicRepository.kt
@@ -2,6 +2,7 @@ package com.hero.ziggymusic.domain.music.repository
 
 import androidx.lifecycle.LiveData
 import com.hero.ziggymusic.database.music.entity.MusicModel
+import kotlinx.coroutines.flow.Flow
 
 interface MusicRepository {
     suspend fun loadMusics()
@@ -13,6 +14,8 @@ interface MusicRepository {
     fun getAllMusic(): LiveData<List<MusicModel>>
 
     fun getFavorites(): LiveData<List<MusicModel>>
+
+    fun observeMusicChanges(): Flow<Unit>
 
     suspend fun addMusicToFavorites(musicModel: MusicModel)
 

--- a/app/src/main/java/com/hero/ziggymusic/playback/MusicMediaItemMapper.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/MusicMediaItemMapper.kt
@@ -1,4 +1,4 @@
-package com.hero.ziggymusic.view.main.player
+package com.hero.ziggymusic.playback
 
 import android.content.Context
 import androidx.media3.common.MediaItem
@@ -10,18 +10,21 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.hero.ziggymusic.database.music.entity.MusicModel
 
+// Player 큐에 등록된 mediaId 목록을 비교할 때 사용한다.
 fun Player.currentMediaIds(): List<String> {
     return (0 until mediaItemCount).map { index ->
         getMediaItemAt(index).mediaId
     }
 }
 
+// 선택한 음원이 현재 Player 큐의 몇 번째 항목인지 찾는다.
 fun Player.findMediaItemIndexById(mediaId: String): Int {
     return (0 until mediaItemCount).firstOrNull { index ->
         getMediaItemAt(index).mediaId == mediaId
     } ?: -1
 }
 
+// MusicModel을 Media3에서 재생 가능한 MediaItem으로 변환한다.
 fun MusicModel.toMediaItem(): MediaItem {
     return MediaItem.Builder()
         .setMediaId(id)
@@ -39,6 +42,7 @@ fun MusicModel.toMediaItem(): MediaItem {
 
 @OptIn(UnstableApi::class)
 fun MusicModel.toProgressiveMediaSource(context: Context): ProgressiveMediaSource {
+    // 앱의 기본 DataSource 설정을 유지하면서 로컬 음원 MediaSource를 생성한다.
     val dataSourceFactory = DefaultDataSource.Factory(context)
 
     return ProgressiveMediaSource.Factory(dataSourceFactory)

--- a/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueManager.kt
@@ -1,0 +1,176 @@
+package com.hero.ziggymusic.playback
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import com.hero.ziggymusic.database.music.entity.MusicModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PlaybackQueueManager @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val player: ExoPlayer
+) {
+    @OptIn(UnstableApi::class)
+    fun prepareQueue(
+        musicList: List<MusicModel>,
+        selectedMusic: MusicModel?,
+        startPositionMs: Long = 0L
+    ) {
+        if (musicList.isEmpty()) return
+
+        // 마지막으로 재생한 곡이 목록에 있으면 해당 위치에서 큐를 시작한다.
+        val startIndex = selectedMusic
+            ?.let { music -> musicList.indexOfFirst { it.id == music.id } }
+            ?.takeIf { it >= 0 }
+            ?: 0
+
+        val mediaSources = musicList.map { music ->
+            music.toProgressiveMediaSource(context)
+        }
+
+        player.setMediaSources(
+            mediaSources,
+            startIndex,
+            startPositionMs.coerceAtLeast(0L)
+        )
+        player.prepare()
+    }
+
+    @OptIn(UnstableApi::class)
+    fun syncQueue(musicList: List<MusicModel>) {
+        if (musicList.isEmpty()) {
+            // 재생 가능한 음원이 없으면 기존 큐를 정리하여 삭제된 항목이 남지 않게 한다.
+            if (player.mediaItemCount > 0) {
+                player.pause()
+                player.clearMediaItems()
+            }
+            return
+        }
+
+        val latestMediaIds = musicList.map { it.id }
+        val currentMediaIds = player.currentMediaIds()
+
+        if (currentMediaIds == latestMediaIds) return
+
+        // 큐를 다시 구성하기 전에 현재 재생 상태를 저장해 복원 여부를 판단한다.
+        val currentMediaId = player.currentMediaItem?.mediaId
+
+        val currentItemStillExists = currentMediaId != null && latestMediaIds.contains(currentMediaId)
+
+        if (currentItemStillExists && canUpdateQueue(currentMediaIds, latestMediaIds)) {
+            updateQueue(
+                currentMediaIds = currentMediaIds,
+                latestMusicList = musicList
+            )
+            return
+        }
+
+        val currentPositionMs = player.currentPosition.coerceAtLeast(0L)
+        val wasPlaying = player.isPlaying
+
+        val restoredIndex = currentMediaId
+            ?.let { mediaId -> musicList.indexOfFirst { it.id == mediaId } }
+            ?.takeIf { it >= 0 }
+
+        val targetIndex = restoredIndex ?: 0
+        val targetPositionMs = if (restoredIndex != null) {
+            currentPositionMs
+        } else {
+            // 현재 곡이 목록에서 사라졌다면 다른 곡의 중간 위치로 복원하지 않는다.
+            0L
+        }
+
+        val shouldResumePlayback = wasPlaying && restoredIndex != null
+
+        val mediaSources = musicList.map { music ->
+            music.toProgressiveMediaSource(context)
+        }
+
+        player.setMediaSources(mediaSources, targetIndex, targetPositionMs)
+        player.prepare()
+
+        if (shouldResumePlayback) {
+            player.play()
+        }
+    }
+
+    // 현재 재생 중인 곡을 유지할 수 있고 기존 곡들의 상대적인 순서가 바뀌지 않았다면
+    // Player 큐를 전체 재생성하지 않고 추가/삭제된 항목만 반영할 수 있다.
+    private fun canUpdateQueue(
+        currentIds: List<String>,
+        latestIds: List<String>
+    ): Boolean {
+        val currentIdSet = currentIds.toSet()
+        val latestIdSet = latestIds.toSet()
+
+        val currentIdsStillInLatest = currentIds.filter { it in latestIdSet }
+        val latestIdsAlreadyInCurrent = latestIds.filter { it in currentIdSet }
+
+        return currentIdsStillInLatest == latestIdsAlreadyInCurrent
+    }
+
+    // 전체 큐를 다시 준비하면 재생이 잠깐 끊길 수 있으므로,
+    // 삭제된 항목은 제거하고 새로 추가된 항목만 현재 Player 큐에 반영한다.
+    @OptIn(UnstableApi::class)
+    private fun updateQueue(
+        currentMediaIds: List<String>,
+        latestMusicList: List<MusicModel>
+    ) {
+        val latestMediaIds = latestMusicList.map { it.id }
+        val queueIds = currentMediaIds.toMutableList()
+
+        for (index in queueIds.lastIndex downTo 0) {
+            if (queueIds[index] !in latestMediaIds) {
+                player.removeMediaItem(index)
+                queueIds.removeAt(index)
+            }
+        }
+
+        latestMusicList.forEachIndexed { targetIndex, music ->
+            if (music.id !in queueIds) {
+                player.addMediaSource(
+                    targetIndex,
+                    music.toProgressiveMediaSource(context)
+                )
+                queueIds.add(targetIndex, music.id)
+            }
+        }
+    }
+
+    fun playMusic(
+        musicList: List<MusicModel>,
+        musicId: String
+    ): Boolean {
+        if (musicList.isEmpty()) return false
+
+        syncQueue(musicList)
+
+        // 큐 동기화 이후 실제 Player 큐에서 선택한 곡의 위치를 다시 찾는다.
+        val targetIndex = player.findMediaItemIndexById(musicId)
+        if (targetIndex == -1) return false
+
+        player.seekTo(targetIndex, 0L)
+        player.play()
+        return true
+    }
+
+    fun moveToFirstTrackAndPauseIfAtEnd(): String? {
+        val isLastTrack = player.currentMediaItemIndex == player.mediaItemCount - 1
+        val isRepeatOff = player.repeatMode == Player.REPEAT_MODE_OFF
+
+        if (!isLastTrack || !isRepeatOff || player.mediaItemCount == 0) {
+            return null
+        }
+
+        // 반복 재생이 꺼진 마지막 곡에서는 첫 곡으로 이동만 하고 자동 재생하지 않는다.
+        player.seekTo(0, 0L)
+        player.pause()
+
+        return player.currentMediaItem?.mediaId
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/service/MusicService.kt
@@ -24,6 +24,7 @@ import androidx.media3.session.MediaStyleNotificationHelper
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.database.music.entity.PlayerModel
+import com.hero.ziggymusic.playback.PlaybackQueueManager
 import com.hero.ziggymusic.view.main.MainActivity
 import javax.inject.Inject
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,6 +33,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class MusicService : MediaLibraryService() {
     @Inject
     lateinit var player: ExoPlayer
+
+    @Inject
+    lateinit var playbackQueueManager: PlaybackQueueManager
 
     private val playerModel: PlayerModel = PlayerModel.getInstance()
 
@@ -162,17 +166,16 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun skipToNextOrMoveToFirstTrack() {
-        if (shouldMoveFromLastTrackToFirstTrack()) {
-            player.playWhenReady = false
-            player.seekTo(0, 0)
-            player.pause()
+        // 반복 재생이 꺼진 마지막 곡에서는 큐 정책에 따라 첫 곡으로 이동만 한다.
+        val firstMediaId = playbackQueueManager.moveToFirstTrackAndPauseIfAtEnd()
 
-            if (player.mediaItemCount > 0) {
-                playerModel.changedMusic(player.getMediaItemAt(0).mediaId)
-            }
-        } else {
-            player.seekToNextMediaItem()
+        if (firstMediaId != null) {
+            playerModel.changedMusic(firstMediaId)
+            updateNotification()
+            return
         }
+
+        player.seekToNextMediaItem()
     }
 
     private fun shouldMoveFromLastTrackToFirstTrack(): Boolean {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -54,7 +54,7 @@ class MusicListFragment : Fragment() {
 
     private lateinit var musicListAdapter: MusicListAdapter
     private var mediaStoreObserver: ContentObserver? = null
-    private var hasRefreshedAfterPermission = false
+    private var isRefreshedAfterPermission = false
     private var searchAnimator: ValueAnimator? = null
     private var isSearchVisible = false
     private var searchProgress = 0f
@@ -95,12 +95,12 @@ class MusicListFragment : Fragment() {
         if (hasAudioPermission()) {
             registerMediaStoreObserverIfNeeded()
 
-            if (!hasRefreshedAfterPermission) {
-                hasRefreshedAfterPermission = true
+            if (!isRefreshedAfterPermission) {
+                isRefreshedAfterPermission = true
                 vm.refreshMusicList()
             }
         } else {
-            hasRefreshedAfterPermission = false
+            isRefreshedAfterPermission = false
         }
 
         vm.startObservingMediaStoreChanges()

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -102,6 +102,8 @@ class MusicListFragment : Fragment() {
         } else {
             hasRefreshedAfterPermission = false
         }
+
+        vm.startObservingMediaStoreChanges()
     }
 
     private fun initRecyclerView(recyclerView: RecyclerView) {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
@@ -63,6 +63,7 @@ class MusicListViewModel @Inject constructor(
         get() = _searchResult
 
     private var isInitialized = false
+    private var isObservingMediaStore = false
     private var hasSearchMusicItems = false
 
     private val allMusicsObserver = Observer<List<MusicModel>> { musics ->
@@ -104,6 +105,8 @@ class MusicListViewModel @Inject constructor(
                 _uiState.value = MusicListUiState.Error
             }
         }
+
+
     }
 
     @OptIn(FlowPreview::class)
@@ -136,6 +139,23 @@ class MusicListViewModel @Inject constructor(
                 _uiState.value = MusicListUiState.Error
             }
         }
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun observeMediaStoreChanges() {
+        viewModelScope.launch {
+            musicRepository.observeMusicChanges()
+                .debounce(MEDIA_STORE_REFRESH_DELAY_MS.milliseconds)
+                .collect {
+                    refreshMusicList()
+                }
+        }
+    }
+
+    fun startObservingMediaStoreChanges() {
+        if (isObservingMediaStore) return
+        isObservingMediaStore = true
+        observeMediaStoreChanges()
     }
 
     fun setSearchQuery(query: String) {
@@ -203,6 +223,7 @@ class MusicListViewModel @Inject constructor(
     }
 
     companion object {
+        private const val MEDIA_STORE_REFRESH_DELAY_MS = 500L
         private const val SEARCH_DEBOUNCE_MS = 200L
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/MusicMediaItemMapper.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/MusicMediaItemMapper.kt
@@ -1,0 +1,46 @@
+package com.hero.ziggymusic.view.main.player
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.hero.ziggymusic.database.music.entity.MusicModel
+
+fun Player.currentMediaIds(): List<String> {
+    return (0 until mediaItemCount).map { index ->
+        getMediaItemAt(index).mediaId
+    }
+}
+
+fun Player.findMediaItemIndexById(mediaId: String): Int {
+    return (0 until mediaItemCount).firstOrNull { index ->
+        getMediaItemAt(index).mediaId == mediaId
+    } ?: -1
+}
+
+fun MusicModel.toMediaItem(): MediaItem {
+    return MediaItem.Builder()
+        .setMediaId(id)
+        .setUri(getMusicFileUri())
+        .setMediaMetadata(
+            MediaMetadata.Builder()
+                .setTitle(title)
+                .setArtist(artist)
+                .setAlbumTitle(album)
+                .setArtworkUri(getAlbumUri())
+                .build()
+        )
+        .build()
+}
+
+@OptIn(UnstableApi::class)
+fun MusicModel.toProgressiveMediaSource(context: Context): ProgressiveMediaSource {
+    val dataSourceFactory = DefaultDataSource.Factory(context)
+
+    return ProgressiveMediaSource.Factory(dataSourceFactory)
+        .createMediaSource(toMediaItem())
+}

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -281,6 +281,8 @@ class PlayerFragment : Fragment() {
                 // 이미 재생 중인 곡이 있으면 playMusic을 다시 호출하지 않는다.
                 if (player.currentMediaItem == null && nowMusic != null) {
                     playMusic(musicList, nowMusic)
+                } else {
+                    syncPlaybackQueueIfNeeded(musicList)
                 }
             }
         }
@@ -295,15 +297,16 @@ class PlayerFragment : Fragment() {
     }
 
     fun changeMusic(musicId: String) {
-        val findIndex = vm.musicList.value.orEmpty()
-            .indexOfFirst {
-                it.id == musicId
-            }
+        val latestMusicList = vm.musicList.value.orEmpty()
+        if (latestMusicList.isEmpty()) return
 
-        if (findIndex != -1) {
-            player.seekTo(findIndex, 0)
-            player.play()
-        }
+        syncPlaybackQueueIfNeeded(latestMusicList)
+
+        val targetIndex = player.findMediaItemIndexById(musicId)
+        if (targetIndex == -1) return
+
+        player.seekTo(targetIndex, 0L)
+        player.play()
     }
 
     private fun initSeekBar() {
@@ -788,24 +791,7 @@ class PlayerFragment : Fragment() {
         }
 
         val musicMediaItems = musicList.map { music ->
-            val defaultDataSourceFactory =
-                DefaultDataSource.Factory(requireContext())
-            val musicFileUri = music.getMusicFileUri()
-            val mediaItem = MediaItem.Builder()
-                .setMediaId(music.id)
-                .setUri(musicFileUri)
-                .setMediaMetadata(
-                    MediaMetadata.Builder()
-                        .setTitle(music.title)
-                        .setArtist(music.artist)
-                        .setAlbumTitle(music.album)
-                        .setArtworkUri(music.getAlbumUri())
-                        .build()
-                )
-                .build()
-
-            ProgressiveMediaSource.Factory(defaultDataSourceFactory)
-                .createMediaSource(mediaItem)
+            music.toProgressiveMediaSource(requireContext())
         }
 
         val playIndex = musicList.indexOf(nowPlayMusic)
@@ -828,6 +814,33 @@ class PlayerFragment : Fragment() {
             setMediaSources(musicMediaItems)
             prepare()
             seekTo(max(playIndex, 0), resumePositionMs) // 마지막 재생 위치에서 시작
+        }
+    }
+
+    private fun syncPlaybackQueueIfNeeded(latestMusicList: List<MusicModel>) {
+        if (latestMusicList.isEmpty()) return
+
+        val currentQueueMediaIds = player.currentMediaIds()
+        val latestLibraryMediaIds = latestMusicList.map { it.id }
+
+        if (currentQueueMediaIds == latestLibraryMediaIds) return
+
+        val currentMediaId = player.currentMediaItem?.mediaId
+        val currentPositionMs = player.currentPosition
+        val wasPlaying = player.isPlaying
+
+        val mediaItems = latestMusicList.map { it.toMediaItem() }
+
+        val restoredIndex = currentMediaId
+            ?.let { mediaId -> latestMusicList.indexOfFirst { it.id == mediaId } }
+            ?.takeIf { index -> index >= 0 }
+            ?: 0
+
+        player.setMediaItems(mediaItems, restoredIndex, currentPositionMs)
+        player.prepare()
+
+        if (wasPlaying) {
+            player.play()
         }
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -24,12 +24,9 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.ShuffleOrder
 import com.bumptech.glide.Glide
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -50,6 +47,9 @@ import androidx.fragment.app.activityViewModels
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
+import com.hero.ziggymusic.playback.PlaybackQueueManager
+import com.hero.ziggymusic.playback.currentMediaIds
+import com.hero.ziggymusic.playback.toMediaItem
 import com.hero.ziggymusic.service.MusicMediaControllerConnector
 import com.hero.ziggymusic.service.MusicServiceController
 import com.hero.ziggymusic.view.main.player.model.LastPlayedMedia
@@ -66,6 +66,9 @@ class PlayerFragment : Fragment() {
 
     @Inject
     lateinit var player: ExoPlayer
+
+    @Inject
+    lateinit var playbackQueueManager: PlaybackQueueManager
 
     private var currentMusic: MusicModel? = null // 현재 재생 중인 음원
     private val playbackStateStore by lazy { PlaybackStateStore(requireContext()) }
@@ -263,6 +266,7 @@ class PlayerFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             vm.musicList.observe(viewLifecycleOwner) { musicList ->
                 if (_binding == null) return@observe
+                if (musicList.isEmpty()) return@observe
 
                 playerModel.replaceMusicList(musicList)
 
@@ -282,7 +286,8 @@ class PlayerFragment : Fragment() {
                 if (player.currentMediaItem == null && nowMusic != null) {
                     playMusic(musicList, nowMusic)
                 } else {
-                    syncPlaybackQueueIfNeeded(musicList)
+                    // 목록이 변경되면 현재 재생 상태를 유지한 채 Player 큐만 최신 목록으로 맞춘다.
+                    playbackQueueManager.syncQueue(musicList)
                 }
             }
         }
@@ -298,15 +303,18 @@ class PlayerFragment : Fragment() {
 
     fun changeMusic(musicId: String) {
         val latestMusicList = vm.musicList.value.orEmpty()
-        if (latestMusicList.isEmpty()) return
+        // 재생 요청 전에 큐를 최신 목록으로 동기화하여 새로 추가된 음원도 바로 재생되게 한다.
+        val startedPlayback = playbackQueueManager.playMusic(
+            musicList = latestMusicList,
+            musicId = musicId
+        )
 
-        syncPlaybackQueueIfNeeded(latestMusicList)
+        if (!startedPlayback) return
 
-        val targetIndex = player.findMediaItemIndexById(musicId)
-        if (targetIndex == -1) return
-
-        player.seekTo(targetIndex, 0L)
-        player.play()
+        playerModel.changedMusic(musicId)
+        playerModel.currentMusic?.let { music ->
+            updatePlayerView(music)
+        }
     }
 
     private fun initSeekBar() {
@@ -406,16 +414,12 @@ class PlayerFragment : Fragment() {
     }
 
     private fun moveToFirstTrack(): Boolean {
-        if (player.repeatMode != Player.REPEAT_MODE_OFF) return false
-        if (player.mediaItemCount <= 0) return false
-        if (player.currentMediaItemIndex != player.mediaItemCount - 1) return false
+        // 마지막 곡에서 다음 버튼을 누른 경우의 Player 조작은 PlaybackQueueManager에 위임한다.
+        val firstId = playbackQueueManager.moveToFirstTrackAndPauseIfAtEnd()
+            ?: return false
 
-        player.playWhenReady = false
-        player.seekTo(0, 0)
-        player.pause()
-
-        val firstId = player.getMediaItemAt(0).mediaId
         playerModel.changedMusic(firstId)
+
         playbackStateStore.saveLastPlayedMedia(
             LastPlayedMedia(
                 type = PlaybackContentType.MUSIC,
@@ -425,6 +429,7 @@ class PlayerFragment : Fragment() {
                 updatedAtMs = System.currentTimeMillis()
             )
         )
+
         updatePlayerView(playerModel.currentMusic)
         updatePlaybackProgress()
         syncPlayerUi()
@@ -782,66 +787,40 @@ class PlayerFragment : Fragment() {
         )
     }
 
-    @OptIn(UnstableApi::class)
     private fun playMusic(musicList: List<MusicModel>, nowPlayMusic: MusicModel?) {
-        if (nowPlayMusic != null) {
-            currentMusic = nowPlayMusic
-            playerModel.updateCurrentMusic(nowPlayMusic)
-            playbackStateStore.saveLastPlayedId(PlaybackContentType.MUSIC, nowPlayMusic.id)
-        }
+        if (nowPlayMusic == null) return
 
-        val musicMediaItems = musicList.map { music ->
-            music.toProgressiveMediaSource(requireContext())
-        }
-
-        val playIndex = musicList.indexOf(nowPlayMusic)
-
-        // 마지막 재생 상태를 로드하고 position을 복원
-        val lastPlayed = playbackStateStore.loadLastPlayedMedia()
+        val lastPlayedMedia = playbackStateStore.loadLastPlayedMedia()
+        // 이전에 같은 음원을 듣고 있었다면 저장된 재생 위치부터 이어서 준비한다.
         val resumePositionMs =
-            if (lastPlayed != null &&
-                lastPlayed.type == PlaybackContentType.MUSIC &&
-                lastPlayed.id.isNotBlank() &&
-                nowPlayMusic != null &&
-                lastPlayed.id == nowPlayMusic.id
+            if (
+                lastPlayedMedia?.type == PlaybackContentType.MUSIC &&
+                lastPlayedMedia.id == nowPlayMusic.id
             ) {
-                lastPlayed.positionMs.coerceAtLeast(0L)
+                lastPlayedMedia.positionMs
             } else {
                 0L
             }
 
-        player.run {
-            setMediaSources(musicMediaItems)
-            prepare()
-            seekTo(max(playIndex, 0), resumePositionMs) // 마지막 재생 위치에서 시작
-        }
-    }
+        playerModel.updateCurrentMusic(nowPlayMusic)
 
-    private fun syncPlaybackQueueIfNeeded(latestMusicList: List<MusicModel>) {
-        if (latestMusicList.isEmpty()) return
+        playbackStateStore.saveLastPlayedMedia(
+            LastPlayedMedia(
+                type = PlaybackContentType.MUSIC,
+                id = nowPlayMusic.id,
+                positionMs = resumePositionMs,
+                playWhenReady = player.playWhenReady,
+                updatedAtMs = System.currentTimeMillis()
+            )
+        )
 
-        val currentQueueMediaIds = player.currentMediaIds()
-        val latestLibraryMediaIds = latestMusicList.map { it.id }
+        playbackQueueManager.prepareQueue(
+            musicList = musicList,
+            selectedMusic = nowPlayMusic,
+            startPositionMs = resumePositionMs
+        )
 
-        if (currentQueueMediaIds == latestLibraryMediaIds) return
-
-        val currentMediaId = player.currentMediaItem?.mediaId
-        val currentPositionMs = player.currentPosition
-        val wasPlaying = player.isPlaying
-
-        val mediaItems = latestMusicList.map { it.toMediaItem() }
-
-        val restoredIndex = currentMediaId
-            ?.let { mediaId -> latestMusicList.indexOfFirst { it.id == mediaId } }
-            ?.takeIf { index -> index >= 0 }
-            ?: 0
-
-        player.setMediaItems(mediaItems, restoredIndex, currentPositionMs)
-        player.prepare()
-
-        if (wasPlaying) {
-            player.play()
-        }
+        updatePlayerView(nowPlayMusic)
     }
 
     private fun drawableToBitmap(drawable: Drawable): Bitmap {


### PR DESCRIPTION
# PR 내용
1. MediaStore 변경 감지 및 음원 목록 갱신
  - 앱 실행 중 외부에서 음원이 추가/삭제되면 MediaStore 변경을 감지해 목록을 갱신하도록 보완
  - RecyclerView에 최신 음원 목록이 바로 반영되도록 Repository/DataSource 갱신 흐름 정리

2. Player 재생 큐 동기화 개선
  - 음원 목록 변경 시 ExoPlayer 큐를 전체 재생성하지 않고 변경된 항목만 반영하도록 개선
  - 재생 중 음원 추가/삭제가 발생해도 현재 재생 중인 곡이 끊기지 않도록 큐 갱신 로직 보완

3. 로컬 음원 DB 갱신 방식 개선
  - 전체 삭제 후 재삽입하던 방식 대신 최신 음원 목록 기준으로 필요한 항목만 추가/삭제하도록 변경
  - 불필요한 DB 변경과 LiveData 갱신 범위를 줄여 목록/플레이어 상태 동기화 안정성 개선