### PR TITLE
[ Feature ] 음악 목록에 즐겨찾기 상태 표시 기능 구현

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListAdapter.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListAdapter.kt
@@ -18,7 +18,12 @@ class MusicListAdapter(
     private val onItemClick: (MusicModel) -> Unit,
     private val onOptionClick: (MusicModel, View) -> Unit,
 ) : ListAdapter<MusicModel, MusicListAdapter.MusicListViewHolder>(DIFF_CALLBACK) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MusicListViewHolder {
+    private var favoriteMusicIds: Set<String> = emptySet() // 중복 ID를 허용하지 않아서 Set을 사용
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): MusicListViewHolder {
         val binding = ItemMusicListBinding.inflate(
             LayoutInflater.from(parent.context),
             parent,
@@ -28,12 +33,55 @@ class MusicListAdapter(
         return MusicListViewHolder(binding)
     }
 
-    override fun onBindViewHolder(holder: MusicListViewHolder, position: Int) {
+    override fun onBindViewHolder(
+        holder: MusicListViewHolder,
+        position: Int,
+    ) {
+        val item = getItem(position)
+
         holder.bind(
-            getItem(position),
-            onItemClick,
-            onOptionClick
+            musicItem = item,
+            isFavorite = item.id in favoriteMusicIds,
+            onItemClick = onItemClick,
+            onOptionClick = onOptionClick,
         )
+    }
+
+    /**
+     * payload가 즐겨찾기 변경을 나타내면 별 아이콘만 부분 갱신한다.
+     * payload가 없거나 처리할 수 없는 변경이면 아이템 전체를 다시 바인딩한다.
+     */
+    override fun onBindViewHolder(
+        holder: MusicListViewHolder,
+        position: Int,
+        payloads: MutableList<Any>,
+    ) {
+        if (PAYLOAD_FAVORITE in payloads) {
+            val item = getItem(position)
+            holder.bindFavoriteMusic(item.id in favoriteMusicIds)
+        } else {
+            onBindViewHolder(holder, position)
+        }
+    }
+
+    /**
+     * 최신 즐겨찾기 음악 ID를 반영하고, 즐겨찾기 상태가 변경된 아이템만
+     * PAYLOAD_FAVORITE를 전달하여 부분 갱신한다.
+     */
+    fun updateFavoriteMusicIds(newFavoriteMusicIds: Set<String>) {
+        if (favoriteMusicIds == newFavoriteMusicIds) return
+
+        val oldFavoriteMusicIds = favoriteMusicIds
+        favoriteMusicIds = newFavoriteMusicIds
+
+        currentList.forEachIndexed { index, music ->
+            val wasFavorite = music.id in oldFavoriteMusicIds
+            val isFavorite = music.id in newFavoriteMusicIds
+
+            if (wasFavorite != isFavorite) {
+                notifyItemChanged(index, PAYLOAD_FAVORITE)
+            }
+        }
     }
 
     class MusicListViewHolder(
@@ -41,17 +89,22 @@ class MusicListAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(
             musicItem: MusicModel,
+            isFavorite: Boolean,
             onItemClick: (MusicModel) -> Unit,
             onOptionClick: (MusicModel, View) -> Unit,
         ) {
+            bindFavoriteMusic(isFavorite)
+
             binding.root.setCardBackgroundColor(
                 if (musicItem.isPlaying) Color.GRAY else Color.TRANSPARENT
             )
+
             Glide.with(binding.ivAlbum)
                 .load(musicItem.getAlbumUri())
                 .error(R.drawable.placeholder_album_art)
                 .fallback(R.drawable.placeholder_album_art)
                 .into(binding.ivAlbum)
+
             binding.tvSongTitle.text = musicItem.title.orEmpty()
             binding.tvSongArtist.text = musicItem.artist.orEmpty()
             binding.tvDuration.text = musicItem.duration.toDurationText()
@@ -65,6 +118,11 @@ class MusicListAdapter(
                 onOptionClick(musicItem, view)
             }
         }
+
+        fun bindFavoriteMusic(isFavorite: Boolean) {
+            binding.ivFavoriteStar.visibility =
+                if (isFavorite) View.VISIBLE else View.INVISIBLE
+        }
     }
 
     companion object {
@@ -77,5 +135,7 @@ class MusicListAdapter(
                 return oldItem == newItem
             }
         }
+
+        private const val PAYLOAD_FAVORITE = "payload_favorite" // 즐겨찾기 표시만 갱신
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -516,6 +516,10 @@ class MusicListFragment : Fragment() {
             }
         }
 
+        vm.favoriteMusicIds.observe(viewLifecycleOwner) { musicIds ->
+            musicListAdapter.updateFavoriteMusicIds(musicIds)
+        }
+
         vm.toastEvent.observe(viewLifecycleOwner) { event ->
             event.getContentIfNotHandled()?.let { message ->
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.common.SingleEvent
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toSet
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -41,6 +43,10 @@ class MusicListViewModel @Inject constructor(
     private val favorites = musicRepository.getFavorites()
     private val favoritesObserver: (List<MusicModel>) -> Unit = {
     }
+
+    val favoriteMusicIds: LiveData<Set<String>> = favorites.map { items ->
+        items.map { it.id }.toSet()
+    } // 전체 음악 목록에서 각 음악의 즐겨찾기 여부를 확인하기 위해 즐겨찾기 음악 목록을 중복 없는 ID 집합으로 변환
 
     val allMusics = musicRepository.getAllMusic()
 

--- a/app/src/main/res/layout/item_music_list.xml
+++ b/app/src/main/res/layout/item_music_list.xml
@@ -16,6 +16,20 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/list_item_height">
 
+        <ImageView
+            android:id="@+id/ivFavoriteStar"
+            android:layout_width="@dimen/music_list_item_favorite_icon_size"
+            android:layout_height="@dimen/music_list_item_favorite_icon_size"
+            android:layout_marginEnd="@dimen/music_list_item_favorite_icon_margin_end"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_favorite_star_filled"
+            android:visibility="invisible"
+            app:tint="@color/colorPrimaryDark"
+            app:layout_constraintBottom_toBottomOf="@id/ivAlbum"
+            app:layout_constraintEnd_toStartOf="@id/ivAlbum"
+            app:layout_constraintTop_toTopOf="@id/ivAlbum"
+            tools:visibility="visible" />
+
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/ivAlbum"
             android:layout_width="@dimen/album_art_size"

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">12dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">3dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">4dp</dimen>
     <dimen name="music_list_item_text_margin_start">8dp</dimen>
     <dimen name="music_list_item_text_margin_end">8dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">12dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">4dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">4dp</dimen>
     <dimen name="music_list_item_text_margin_start">10dp</dimen>
     <dimen name="music_list_item_text_margin_end">8dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">20dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">12dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">5dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">4dp</dimen>
     <dimen name="music_list_item_text_margin_start">10dp</dimen>
     <dimen name="music_list_item_text_margin_end">8dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">20dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">14dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">5dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">4dp</dimen>
     <dimen name="music_list_item_text_margin_start">12dp</dimen>
     <dimen name="music_list_item_text_margin_end">10dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">22dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">16dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">6dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">6dp</dimen>
     <dimen name="music_list_item_text_margin_start">16dp</dimen>
     <dimen name="music_list_item_text_margin_end">12dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">24dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">16dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">6dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">6dp</dimen>
     <dimen name="music_list_item_text_margin_start">16dp</dimen>
     <dimen name="music_list_item_text_margin_end">12dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -40,6 +40,8 @@
     <dimen name="card_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
+    <dimen name="music_list_item_favorite_icon_size">12dp</dimen>
+    <dimen name="music_list_item_favorite_icon_margin_end">4dp</dimen>
     <dimen name="music_list_item_title_artist_spacing">4dp</dimen>
     <dimen name="music_list_item_text_margin_start">10dp</dimen>
     <dimen name="music_list_item_text_margin_end">8dp</dimen>


### PR DESCRIPTION
# PR 내용
1. 음악 목록에 즐겨찾기 상태 아이콘 추가
  - 앨범 아트 왼쪽에 즐겨찾기 별 아이콘 배치
  - 즐겨찾기 여부에 따라 아이콘의 VISIBLE/INVISIBLE 상태 처리
  - 화면 크기별 아이콘 크기와 여백 조정

2. RecyclerView 부분 갱신 적용
  - 즐겨찾기 상태가 변경된 아이템만 갱신
  - payload를 사용해 별 아이콘만 부분 바인딩하고 불필요한 Glide 재호출과 아이템 깜빡임 방지

3. 즐겨찾기 상태 관찰 로직 추가
  - 즐겨찾기 음악 목록을 favoriteMusicIds로 변환해 상태 노출 
  - Fragment에서 즐겨찾기 ID 변경을 관찰해 Adapter에 전달
  - Set을 활용해 음악별 즐겨찾기 여부를 효율적으로 조회