### PR TITLE
[ Fix ] 음악 목록 동기화 구조 개선 및 메인 화면 프래그먼트 상태 보완

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSource.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSource.kt
@@ -5,7 +5,11 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import kotlinx.coroutines.flow.Flow
 
 interface MusicLocalDataSource {
-    suspend fun loadMusics()
+    // MediaStore에서 현재 음원 목록 조회
+    suspend fun getMusicList(): List<MusicModel>
+
+    // Room 캐시를 최신 목록으로 교체
+    suspend fun replaceCachedMusicList(musicList: List<MusicModel>)
 
     suspend fun getMusicCount(): Int
 

--- a/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/local/MusicLocalDataSourceImpl.kt
@@ -21,53 +21,61 @@ class MusicLocalDataSourceImpl @Inject constructor(
     private val favoritesDao: FavoritesDao,
     private val mediaStoreMusicObserver: MediaStoreMusicObserver,
 ) : MusicLocalDataSource {
-    override suspend fun loadMusics() = withContext(Dispatchers.IO) {
-        val musicListUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+    override suspend fun getMusicList(): List<MusicModel> =
+        withContext(Dispatchers.IO) {
+            val musicListUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
 
-        // 2. 가져올 데이터 컬럼을 정의
-        val projection = arrayOf(
-            MediaStore.Audio.Media._ID,
-            MediaStore.Audio.Media.TITLE,
-            MediaStore.Audio.Media.ARTIST,
-            MediaStore.Audio.Media.ALBUM_ID,
-            MediaStore.Audio.Media.ALBUM,
-            MediaStore.Audio.Media.DURATION
-        )
+            // 1. 가져올 데이터 컬럼을 정의
+            val projection = arrayOf(
+                MediaStore.Audio.Media._ID,
+                MediaStore.Audio.Media.TITLE,
+                MediaStore.Audio.Media.ARTIST,
+                MediaStore.Audio.Media.ALBUM_ID,
+                MediaStore.Audio.Media.ALBUM,
+                MediaStore.Audio.Media.DURATION
+            )
 
-        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} > 0"
-        val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC"
+            val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} > 0"
+            val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC"
 
-        // 3. 콘텐츠 리졸버에 해당 데이터 요청 (음원 목록에 있는 0번째 줄을 가리킴)
-        // 4. 커서로 전달된 데이터를 꺼내서 저장
-        val musicList = mutableListOf<MusicModel>()
+            // 2. 콘텐츠 리졸버에 해당 데이터 요청 (음원 목록에 있는 0번째 줄을 가리킴)
+            // 3. 커서로 전달된 데이터를 꺼내서 저장
+            val musicList = mutableListOf<MusicModel>()
 
-        application.contentResolver.query(
-            musicListUri,
-            projection,
-            selection,
-            null,
-            sortOrder
-        )?.use { cursor ->
-            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
-            val titleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
-            val artistColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
-            val albumIdColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
-            val albumTitleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
-            val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            application.contentResolver.query(
+                musicListUri,
+                projection,
+                selection,
+                null,
+                sortOrder
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+                val titleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+                val artistColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+                val albumIdColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
+                val albumTitleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+                val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
 
-            while (cursor.moveToNext()) {
-                val music = MusicModel(
-                    id = cursor.getString(idColumn),
-                    title = cursor.getString(titleColumn),
-                    artist = cursor.getString(artistColumn),
-                    albumId = cursor.getString(albumIdColumn),
-                    album = cursor.getString(albumTitleColumn),
-                    duration = cursor.getLong(durationColumn)
-                )
-                musicList.add(music)
+                while (cursor.moveToNext()) {
+                    val music = MusicModel(
+                        id = cursor.getString(idColumn),
+                        title = cursor.getString(titleColumn),
+                        artist = cursor.getString(artistColumn),
+                        albumId = cursor.getString(albumIdColumn),
+                        album = cursor.getString(albumTitleColumn),
+                        duration = cursor.getLong(durationColumn)
+                    )
+
+                    musicList.add(music)
+                }
             }
+
+            musicList
         }
 
+    override suspend fun replaceCachedMusicList(
+        musicList: List<MusicModel>
+    ) = withContext(Dispatchers.IO) {
         appMusicDatabase.withTransaction {
             musicFileDao.insertAll(musicList)
 

--- a/app/src/main/java/com/hero/ziggymusic/database/music/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/music/repository/MusicRepositoryImpl.kt
@@ -10,8 +10,14 @@ import javax.inject.Inject
 class MusicRepositoryImpl @Inject constructor(
     private val musicLocalDataSource: MusicLocalDataSource
 ) : MusicRepository {
-    override suspend fun loadMusics() {
-        return musicLocalDataSource.loadMusics()
+    override suspend fun getMusicList(): List<MusicModel> {
+        return musicLocalDataSource.getMusicList()
+    }
+
+    override suspend fun replaceCachedMusicList(
+        musicList: List<MusicModel>
+    ) {
+        return musicLocalDataSource.replaceCachedMusicList(musicList)
     }
 
     override suspend fun getMusicCount(): Int {

--- a/app/src/main/java/com/hero/ziggymusic/domain/music/repository/MusicRepository.kt
+++ b/app/src/main/java/com/hero/ziggymusic/domain/music/repository/MusicRepository.kt
@@ -5,7 +5,9 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import kotlinx.coroutines.flow.Flow
 
 interface MusicRepository {
-    suspend fun loadMusics()
+    suspend fun getMusicList(): List<MusicModel>
+
+    suspend fun replaceCachedMusicList(musicList: List<MusicModel>)
 
     suspend fun getMusicCount(): Int
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.core.net.toUri
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -37,6 +36,9 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.doOnPreDraw
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import com.hero.ziggymusic.service.MusicService
 import com.hero.ziggymusic.service.MusicServiceController
 import com.hero.ziggymusic.view.main.model.MainTitle
@@ -50,9 +52,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(),
-    NavigationBarView.OnItemSelectedListener {
-
+class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListener {
     private lateinit var binding: ActivityMainBinding
     private val vm by viewModels<MainViewModel>()
     private val playerVm by viewModels<PlayerViewModel>()
@@ -62,15 +62,6 @@ class MainActivity : AppCompatActivity(),
     private val playerModel: PlayerModel = PlayerModel.getInstance()
     private lateinit var playerController: PlayerController
     private val playbackStateStore by lazy { PlaybackStateStore(this) }
-
-    private val playerListener = object : Player.Listener {
-        // 미디어 아이템이 바뀔 때
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            super.onMediaItemTransition(mediaItem, reason)
-            val newMusicKey: String = mediaItem?.mediaId ?: return
-            playerModel.changedMusic(newMusicKey)
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -119,29 +110,86 @@ class MainActivity : AppCompatActivity(),
             supportFragmentManager.popBackStack()
         }
 
+        // 백스택 변화에 맞춰 현재 화면의 타이틀과 상단 버튼 상태를 동기화한다.
         supportFragmentManager.addOnBackStackChangedListener {
-            when (supportFragmentManager.findFragmentById(binding.fcvMain.id)) {
+            val currentFragment =
+                supportFragmentManager.fragments
+                    .lastOrNull { fragment ->
+                        fragment.id == binding.fcvMain.id &&
+                                fragment.isAdded &&
+                                !fragment.isHidden
+                    }
+
+            when (currentFragment) {
                 is MusicListFragment -> vm.setTitle(MainTitle.MusicList)
                 is FavoritesFragment -> vm.setTitle(MainTitle.Favorites)
                 is SettingFragment -> vm.setTitle(MainTitle.Setting)
             }
         }
 
+        // 현재 메인 탭을 숨기고 설정 화면을 백스택 위에 표시한다.
         binding.ivSetting.setOnClickListener {
-            val settingFragment = supportFragmentManager.findFragmentByTag("setting")
-                ?: SettingFragment.newInstance()
+            // 설정 화면이 이미 표시 중이면 중복 실행하지 않는다.
+            val existingSettingFragment =
+                supportFragmentManager.findFragmentByTag(TAG_SETTING)
+
+            if (
+                existingSettingFragment != null &&
+                existingSettingFragment.isAdded &&
+                !existingSettingFragment.isHidden
+            ) {
+                return@setOnClickListener
+            }
+
+            val currentMainFragment =
+                findCurrentMainTabFragment()
+                    ?: return@setOnClickListener
+
+            val settingFragment = existingSettingFragment ?: SettingFragment.newInstance()
 
             supportFragmentManager.beginTransaction()
-                .replace(binding.fcvMain.id, settingFragment, "setting")
-                .addToBackStack("setting")
+                .setReorderingAllowed(true)
+                .hide(currentMainFragment)
+                .setMaxLifecycle(
+                    currentMainFragment,
+                    Lifecycle.State.STARTED
+                )
+                .apply {
+                    if (settingFragment.isAdded) {
+                        show(settingFragment)
+                    } else {
+                        add(
+                            binding.fcvMain.id,
+                            settingFragment,
+                            TAG_SETTING
+                        )
+                    }
+                }
+                .setMaxLifecycle(
+                    settingFragment,
+                    Lifecycle.State.RESUMED
+                )
+                .setPrimaryNavigationFragment(settingFragment)
+                .addToBackStack(TAG_SETTING)
                 .commit()
-            supportFragmentManager.executePendingTransactions()
-
-            vm.setTitle(MainTitle.Setting)
         }
 
+        initMainTabFragments()
+
         binding.bottomNavMain.setOnItemSelectedListener(this)
-        binding.bottomNavMain.selectedItemId = R.id.menu_music_list
+        binding.bottomNavMain.setOnItemReselectedListener {
+            val settingFragment = supportFragmentManager.findFragmentByTag(TAG_SETTING)
+
+            if (
+                settingFragment != null &&
+                settingFragment.isAdded &&
+                !settingFragment.isHidden
+            ) {
+                supportFragmentManager.popBackStackImmediate()
+            }
+        }
+
+        prepareFavoritesTabAfterFirstDraw()
     }
 
     override fun onStart() {
@@ -151,12 +199,7 @@ class MainActivity : AppCompatActivity(),
     override fun onResume() {
         super.onResume()
 
-        if (hasAudioPermission()) {
-            playerController.startPlayer(
-                playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty()
-            )
-            startMusicServiceIfNotificationAllowed()
-        }
+        startPlayerIfAudioPermissionGranted()
     }
 
     private fun initViewModel() {
@@ -202,22 +245,184 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
-        val transaction = supportFragmentManager.beginTransaction()
-        when (item.itemId) {
+        val settingFragment = supportFragmentManager.findFragmentByTag(TAG_SETTING)
+
+        // 설정 화면 위에서 탭을 누르면 설정을 닫고 선택한 탭으로 돌아간다.
+        if (
+            settingFragment != null &&
+            settingFragment.isAdded &&
+            !settingFragment.isHidden
+        ) {
+            supportFragmentManager.popBackStackImmediate()
+        }
+
+        return when (item.itemId) {
             R.id.menu_music_list -> {
-                val fragment = supportFragmentManager.findFragmentByTag("music_list")
-                    ?: MusicListFragment.newInstance()
-                transaction.replace(binding.fcvMain.id, fragment, "music_list").commit()
+                showMainTab(
+                    tag = TAG_MUSIC_LIST,
+                    createFragment = { MusicListFragment.newInstance() }
+                )
                 vm.setTitle(MainTitle.MusicList)
+                true
             }
+
             R.id.menu_favorites -> {
-                val fragment = supportFragmentManager.findFragmentByTag("favorites")
-                    ?: FavoritesFragment.newInstance()
-                transaction.replace(binding.fcvMain.id, fragment, "favorites").commit()
+                showMainTab(
+                    tag = TAG_FAVORITES,
+                    createFragment = { FavoritesFragment.newInstance() }
+                )
                 vm.setTitle(MainTitle.Favorites)
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    // 복원된 화면이 있으면 UI 상태를 맞추고, 없으면 음악 탭을 초기 화면으로 표시한다.
+    private fun initMainTabFragments() {
+        val restoredFragment = findCurrentMainTabFragment()
+
+        if (restoredFragment != null) {
+            when (restoredFragment.tag) {
+                TAG_FAVORITES -> {
+                    binding.bottomNavMain.selectedItemId = R.id.menu_favorites
+                    vm.setTitle(MainTitle.Favorites)
+                }
+
+                else -> {
+                    binding.bottomNavMain.selectedItemId = R.id.menu_music_list
+                    vm.setTitle(MainTitle.MusicList)
+                }
             }
         }
-        return true
+
+        val musicListFragment =
+            supportFragmentManager.findFragmentByTag(TAG_MUSIC_LIST)
+                ?: MusicListFragment.newInstance()
+
+        supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .apply {
+                if (musicListFragment.isAdded) {
+                    show(musicListFragment)
+                } else {
+                    add(
+                        binding.fcvMain.id,
+                        musicListFragment,
+                        TAG_MUSIC_LIST
+                    )
+                }
+
+                setMaxLifecycle(
+                    musicListFragment,
+                    Lifecycle.State.RESUMED
+                )
+                setPrimaryNavigationFragment(musicListFragment)
+            }
+            .commitNow()
+
+        binding.bottomNavMain.selectedItemId = R.id.menu_music_list
+    }
+
+    // 현재 탭을 숨기고 요청한 메인 탭을 표시한다.
+    private fun showMainTab(
+        tag: String,
+        createFragment: () -> Fragment
+    ) {
+        val fragmentManager = supportFragmentManager
+        val currentFragment = findCurrentMainTabFragment()
+        val targetFragment =
+            fragmentManager.findFragmentByTag(tag) ?: createFragment()
+
+        // 현재 표시 중인 탭을 다시 선택한 경우
+        if (currentFragment === targetFragment) {
+            return
+        }
+
+        fragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .apply {
+                if (currentFragment != null) {
+                    hide(currentFragment)
+                    setMaxLifecycle(
+                        currentFragment,
+                        Lifecycle.State.STARTED
+                    )
+                }
+
+                if (targetFragment.isAdded) {
+                    show(targetFragment)
+                } else {
+                    add(
+                        binding.fcvMain.id,
+                        targetFragment,
+                        tag
+                    )
+                }
+
+                setMaxLifecycle(
+                    targetFragment,
+                    Lifecycle.State.RESUMED
+                )
+                setPrimaryNavigationFragment(targetFragment)
+            }
+            .commit()
+    }
+
+    private fun findCurrentMainTabFragment(): Fragment? {
+        return supportFragmentManager.fragments
+            .lastOrNull { fragment ->
+                fragment.id == binding.fcvMain.id &&
+                        fragment.isAdded &&
+                        !fragment.isHidden &&
+                        (
+                                fragment.tag == TAG_MUSIC_LIST ||
+                                        fragment.tag == TAG_FAVORITES
+                                )
+            }
+    }
+
+    // 첫 화면 렌더링 이후 즐겨찾기 탭을 미리 준비한다.
+    private fun prepareFavoritesTabAfterFirstDraw() {
+        binding.root.doOnPreDraw {
+            binding.root.post {
+                prepareFavoritesTabFragment()
+            }
+        }
+    }
+
+    // 즐겨찾기 탭 프래그먼트를 숨긴 상태로 미리 추가한다.
+    private fun prepareFavoritesTabFragment() {
+        if (isFinishing || isDestroyed) {
+            return
+        }
+
+        // 화면 상태가 이미 저장된 이후에는 Fragment 트랜잭션을 실행하지 않는다.
+        if (supportFragmentManager.isStateSaved) {
+            return
+        }
+
+        // 화면 회전 복원이나 이전 초기화로 이미 존재하면 재생성하지 않는다.
+        if (supportFragmentManager.findFragmentByTag(TAG_FAVORITES) != null) {
+            return
+        }
+
+        val favoritesFragment = FavoritesFragment.newInstance()
+
+        supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .add(
+                binding.fcvMain.id,
+                favoritesFragment,
+                TAG_FAVORITES
+            )
+            .hide(favoritesFragment)
+            .setMaxLifecycle(
+                favoritesFragment,
+                Lifecycle.State.STARTED
+            )
+            .commitNow()
     }
 
     private fun startMusicServiceIfNotificationAllowed() {
@@ -265,8 +470,7 @@ class MainActivity : AppCompatActivity(),
             }
         }
         if (needs.isEmpty()) {
-            playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
-            startMusicServiceIfNotificationAllowed()
+            startPlayerIfAudioPermissionGranted()
         } else {
             permissionLauncher.launch(needs.toTypedArray())
         }
@@ -290,8 +494,7 @@ class MainActivity : AppCompatActivity(),
         }
 
         // 오디오 권한 허용됨 -> 핵심 기능 시작
-        playerController.startPlayer(playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty())
-        startMusicServiceIfNotificationAllowed()
+        startPlayerIfAudioPermissionGranted()
 
         // 알림 권한 선택적 처리
         if (!notifGranted) {
@@ -302,6 +505,15 @@ class MainActivity : AppCompatActivity(),
                 showPermissionDeniedPermanentlyDialog(forNotification = true)
             }
         }
+    }
+
+    private fun startPlayerIfAudioPermissionGranted() {
+        if (!hasAudioPermission()) return
+
+        playerController.startPlayer(
+            playbackStateStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty()
+        )
+        startMusicServiceIfNotificationAllowed()
     }
 
     // Rationale 필요 여부 판단
@@ -456,5 +668,11 @@ class MainActivity : AppCompatActivity(),
                 }
             })
         }
+    }
+
+    companion object {
+        private const val TAG_MUSIC_LIST = "music_list"
+        private const val TAG_FAVORITES = "favorites"
+        private const val TAG_SETTING = "setting"
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -482,7 +482,10 @@ class MusicListFragment : Fragment() {
                 }
 
                 is MusicListUiState.Empty -> {
-                    vm.setSearchMusicItems(emptyList())
+                    vm.setSearchMusicItems(
+                        musicItems = emptyList(),
+                        emptyStateMessage = state.message
+                    )
                 }
 
                 is MusicListUiState.Error -> {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -4,14 +4,10 @@ import android.Manifest
 import android.animation.ValueAnimator
 import android.content.Context
 import android.content.pm.PackageManager
-import android.database.ContentObserver
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.provider.MediaStore
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
@@ -53,7 +49,6 @@ class MusicListFragment : Fragment() {
     private val vm by viewModels<MusicListViewModel>()
 
     private lateinit var musicListAdapter: MusicListAdapter
-    private var mediaStoreObserver: ContentObserver? = null
     private var isRefreshedAfterPermission = false
     private var searchAnimator: ValueAnimator? = null
     private var isSearchVisible = false
@@ -84,26 +79,19 @@ class MusicListFragment : Fragment() {
         collectUiState()
     }
 
-    override fun onStart() {
-        super.onStart()
-        registerMediaStoreObserverIfNeeded()
-    }
-
     override fun onResume() {
         super.onResume()
 
         if (hasAudioPermission()) {
-            registerMediaStoreObserverIfNeeded()
-
             if (!isRefreshedAfterPermission) {
                 isRefreshedAfterPermission = true
-                vm.refreshMusicList()
+                vm.syncMusicLibrary()
             }
+
+            vm.startObservingMediaStoreChanges()
         } else {
             isRefreshedAfterPermission = false
         }
-
-        vm.startObservingMediaStoreChanges()
     }
 
     private fun initRecyclerView(recyclerView: RecyclerView) {
@@ -527,31 +515,6 @@ class MusicListFragment : Fragment() {
         }
     }
 
-    private fun registerMediaStoreObserverIfNeeded() {
-        if (!hasAudioPermission()) return
-        if (mediaStoreObserver != null) return
-
-        mediaStoreObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
-            override fun onChange(selfChange: Boolean) {
-                super.onChange(selfChange)
-                vm.refreshMusicList()
-            }
-        }
-
-        requireContext().contentResolver.registerContentObserver(
-            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-            true,
-            mediaStoreObserver!!
-        )
-    }
-
-    private fun unregisterMediaStoreObserver() {
-        mediaStoreObserver?.let { observer ->
-            requireContext().contentResolver.unregisterContentObserver(observer)
-        }
-        mediaStoreObserver = null
-    }
-
     private fun hasAudioPermission(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             ContextCompat.checkSelfPermission(
@@ -590,11 +553,6 @@ class MusicListFragment : Fragment() {
     private fun removeMusicFromFavorites(id: String) {
         // Local DB에서 삭제한다.
         vm.removeMusicFromMyFavorites(id)
-    }
-
-    override fun onStop() {
-        unregisterMediaStoreObserver()
-        super.onStop()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
@@ -25,7 +25,7 @@ import kotlin.time.Duration.Companion.milliseconds
 sealed class MusicListUiState {
     object Idle : MusicListUiState()
     data class Content(val data: List<MusicModel>) : MusicListUiState()
-    object Empty : MusicListUiState()
+    data class Empty(val message: String) : MusicListUiState()
     object Error : MusicListUiState()
 }
 
@@ -53,9 +53,7 @@ class MusicListViewModel @Inject constructor(
     val uiState: LiveData<MusicListUiState>
         get() = _uiState
 
-    private val _emptyStateMessage = MutableLiveData("")
-    val emptyStateMessage: LiveData<String>
-        get() = _emptyStateMessage
+    private var currentStateMessage: String = "" // 현재 상태를 나타내는 메시지
 
     private val _toastEvent = MutableLiveData<SingleEvent<String>>()
     val toastEvent: LiveData<SingleEvent<String>>
@@ -109,12 +107,9 @@ class MusicListViewModel @Inject constructor(
         musicList: List<MusicModel>
     ) {
         if (musicList.isEmpty()) {
-            _emptyStateMessage.value =
-                getApplication<Application>().getString(R.string.no_music_found)
-
-            _uiState.value = MusicListUiState.Empty
+            val message = getApplication<Application>().getString(R.string.no_music_found)
+            _uiState.value = MusicListUiState.Empty(message)
         } else {
-            _emptyStateMessage.value = ""
             _uiState.value = MusicListUiState.Content(musicList)
         }
     }
@@ -159,8 +154,13 @@ class MusicListViewModel @Inject constructor(
         _searchQuery.value = query
     }
 
-    fun setSearchMusicItems(musicItems: List<MusicModel>) {
+    fun setSearchMusicItems(
+        musicItems: List<MusicModel>,
+        emptyStateMessage: String = ""
+    ) {
         hasSearchMusicItems = true
+        currentStateMessage = emptyStateMessage
+
         _searchMusicItems.value = musicItems
         // 목록이 갱신되면 현재 검색어를 즉시 다시 적용해 화면 상태를 맞춘다.
         _searchResult.value = searchMusicItems(_searchQuery.value, musicItems)
@@ -168,6 +168,7 @@ class MusicListViewModel @Inject constructor(
 
     fun clearSearchResult() {
         hasSearchMusicItems = false
+        currentStateMessage = ""
         _searchMusicItems.value = emptyList()
         _searchResult.value = null
     }
@@ -185,7 +186,7 @@ class MusicListViewModel @Inject constructor(
         }
 
         val emptyMessage = if (keyword.isBlank()) {
-            _emptyStateMessage.value.orEmpty()
+            currentStateMessage
         } else {
             getApplication<Application>().getString(R.string.music_search_no_result)
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/viewmodel/MusicListViewModel.kt
@@ -13,6 +13,7 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
@@ -39,12 +40,14 @@ class MusicListViewModel @Inject constructor(
     application: Application,
     private val musicRepository : MusicRepository
 ) : AndroidViewModel(application) {
+    private var musicLibrarySyncJob: Job? = null // 음악 목록 동기화 중복 실행을 방지한다.
+    private var mediaStoreChangesJob: Job? = null // MediaStore 변경 감지 작업의 중복 실행을 방지한다.
 
     val favoriteMusicIdList: LiveData<Set<String>> = musicRepository.getFavoriteMusicIdList().map { musicIdList ->
         musicIdList.toSet()
     } // 전체 음악 목록에서 각 음악의 즐겨찾기 여부를 확인하기 위해 즐겨찾기 음악 목록을 중복 없는 ID 집합으로 변환
 
-    val allMusics = musicRepository.getAllMusic()
+    val allMusicList = musicRepository.getAllMusic()
 
     private val _uiState = MutableLiveData<MusicListUiState>(MusicListUiState.Idle)
     val uiState: LiveData<MusicListUiState>
@@ -64,50 +67,56 @@ class MusicListViewModel @Inject constructor(
     val searchResult: StateFlow<MusicSearchResult?>
         get() = _searchResult
 
-    private var isInitialized = false
-    private var isObservingMediaStore = false
     private var hasSearchMusicItems = false
 
-    private val allMusicsObserver = Observer<List<MusicModel>> { musics ->
-        if (!isInitialized) return@Observer
-
-        _uiState.value = if (musics.isEmpty()) {
-            MusicListUiState.Empty
-        } else {
-            MusicListUiState.Content(musics)
+    private val allMusicListObserver = Observer<List<MusicModel>> { musicList ->
+        if (musicList.isNotEmpty()) {
+            updateMusicListUiState(musicList)
         }
     }
 
     init {
         // Observer 는 항상 활성 상태로 간주되므로 항상 수정 관련 알림을 받는다.
-        allMusics.observeForever(allMusicsObserver)
+        allMusicList.observeForever(allMusicListObserver)
         observeSearchQuery()
+    }
 
-        viewModelScope.launch {
+    // MediaStore에서 최신 음악 목록을 조회하고, UI 갱신 후 Room 캐시를 갱신한다.
+    fun syncMusicLibrary() {
+        // 이미 동기화 중이면 새 요청은 무시한다.
+        if (musicLibrarySyncJob?.isActive == true) {
+            return
+        }
+
+        musicLibrarySyncJob = viewModelScope.launch {
             runCatching {
-                if (musicRepository.getMusicCount() == 0) {
-                    musicRepository.loadMusics()
-                }
-            }.onSuccess {
-                isInitialized = true
+                musicRepository.getMusicList()
+            }.onSuccess { musicList ->
+                updateMusicListUiState(musicList)
 
-                val musics = allMusics.value.orEmpty()
-                if (musics.isEmpty()) {
-                    _emptyStateMessage.value =
-                        getApplication<Application>().getString(R.string.no_music_found)
-                    _uiState.value = MusicListUiState.Empty
-                } else {
-                    _emptyStateMessage.value = ""
-                    _uiState.value = MusicListUiState.Content(musics)
-                }
+                // 사용자에게 먼저 목록을 보여준 뒤 캐시를 저장한다.
+                musicRepository.replaceCachedMusicList(musicList)
             }.onFailure {
-                isInitialized = true
-                _toastEvent.value = SingleEvent(getApplication<Application>().getString(R.string.load_music_failed))
+                _toastEvent.value = SingleEvent(getApplication<Application>()
+                        .getString(R.string.load_music_failed)
+                )
                 _uiState.value = MusicListUiState.Error
             }
         }
+    }
 
+    private fun updateMusicListUiState(
+        musicList: List<MusicModel>
+    ) {
+        if (musicList.isEmpty()) {
+            _emptyStateMessage.value =
+                getApplication<Application>().getString(R.string.no_music_found)
 
+            _uiState.value = MusicListUiState.Empty
+        } else {
+            _emptyStateMessage.value = ""
+            _uiState.value = MusicListUiState.Content(musicList)
+        }
     }
 
     @OptIn(FlowPreview::class)
@@ -129,34 +138,21 @@ class MusicListViewModel @Inject constructor(
         }
     }
 
-    fun refreshMusicList() {
-        viewModelScope.launch {
-            runCatching {
-                musicRepository.loadMusics()
-            }.onFailure {
-                _toastEvent.value = SingleEvent(
-                    getApplication<Application>().getString(R.string.load_music_failed)
-                )
-                _uiState.value = MusicListUiState.Error
-            }
-        }
-    }
-
+    // MediaStore 변경을 감지해 음악 목록을 최신 상태로 동기화한다.
     @OptIn(FlowPreview::class)
-    private fun observeMediaStoreChanges() {
-        viewModelScope.launch {
+    fun startObservingMediaStoreChanges() {
+        if (mediaStoreChangesJob?.isActive == true) {
+            return
+        }
+
+        // 짧은 시간에 여러 변경 이벤트가 발생해도 한 번만 동기화한다.
+        mediaStoreChangesJob = viewModelScope.launch {
             musicRepository.observeMusicChanges()
                 .debounce(MEDIA_STORE_REFRESH_DELAY_MS.milliseconds)
                 .collect {
-                    refreshMusicList()
+                    syncMusicLibrary()
                 }
         }
-    }
-
-    fun startObservingMediaStoreChanges() {
-        if (isObservingMediaStore) return
-        isObservingMediaStore = true
-        observeMediaStoreChanges()
     }
 
     fun setSearchQuery(query: String) {
@@ -218,7 +214,7 @@ class MusicListViewModel @Inject constructor(
     }
 
     override fun onCleared() {
-        allMusics.removeObserver(allMusicsObserver)
+        allMusicList.removeObserver(allMusicListObserver)
         super.onCleared()
     }
 


### PR DESCRIPTION
# PR 내용
1. 음악 목록 동기화 구조 개선
  - MediaStore 조회와 Room 캐시 갱신 로직을 분리
  - 음악 목록 동기화 중복 실행을 방지하도록 Job 기반 처리 추가
  - MediaStore 변경 감지를 ViewModel로 이관하고 debounce 적용

2. 음악 목록 UI 상태 처리 개선
  - 빈 목록 상태 메시지를 UiState에 포함하도록 변경
  - 검색 결과 없음과 전체 음악 없음 메시지 처리를 정리
  - Fragment의 MediaStore observer 관리 책임을 ViewModel로 이동

3. MainActivity 프래그먼트 전환 로직 보완
  - 음악/즐겨찾기 탭을 replace 방식에서 hide/show 방식으로 전환
  - 설정 화면을 백스택 위에 표시하고, 탭 클릭 시 설정 화면을 닫도록 처리
  - 화면 복원 시 선택된 탭과 타이틀 상태가 유지되도록 보완

4. 즐겨찾기 탭 초기 표시 성능 보완
  - 첫 화면 렌더링 이후 즐겨찾기 Fragment를 숨긴 상태로 미리 준비
  - 이미 생성된 즐겨찾기 Fragment는 중복 생성하지 않도록 처리

5. 플레이어 시작 처리 정리
  - 권한 확인 후 플레이어를 시작하는 공통 메서드 추가
  - onResume, 권한 요청 결과, 초기 권한 확인 흐름의 중복 호출 구조 정리