### PR TITLE
[ UI ] 검색 창 좌우 margin 조정

### DIFF
--- a/app/src/main/res/layout/item_favorites.xml
+++ b/app/src/main/res/layout/item_favorites.xml
@@ -9,7 +9,7 @@
     app:cardCornerRadius="@dimen/album_art_corner_radius"
     app:cardElevation="0dp"
     app:cardUseCompatPadding="false"
-    app:contentPadding="@dimen/card_padding"
+    app:contentPadding="@dimen/music_list_item_card_content_padding"
     app:rippleColor="@color/colorPrimary30">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_music_list.xml
+++ b/app/src/main/res/layout/item_music_list.xml
@@ -9,7 +9,7 @@
     app:cardCornerRadius="@dimen/album_art_corner_radius"
     app:cardElevation="0dp"
     app:cardUseCompatPadding="false"
-    app:contentPadding="@dimen/card_padding"
+    app:contentPadding="@dimen/music_list_item_card_content_padding"
     app:rippleColor="@color/colorPrimary30">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">30dp</dimen>
     <dimen name="toolbar_icon_touch_size">48dp</dimen>
     <dimen name="toolbar_icon_padding">14dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">10dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">13dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">22dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">11dp</dimen>
     <dimen name="music_search_container_height">50dp</dimen>
     <dimen name="music_search_field_height">42dp</dimen>
     <dimen name="music_search_list_safe_gap">0dp</dimen>

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">5dp</dimen>
     <dimen name="btn_height">44dp</dimen>
     <dimen name="toolbar_height">52dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">12dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">5dp</dimen>
     <dimen name="btn_height">48dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">12dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">32dp</dimen>
     <dimen name="toolbar_icon_touch_size">48dp</dimen>
     <dimen name="toolbar_icon_padding">14dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">15dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">18dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">22dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">12dp</dimen>
     <dimen name="music_search_container_height">52dp</dimen>
     <dimen name="music_search_field_height">44dp</dimen>
     <dimen name="music_search_list_safe_gap">0dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">34dp</dimen>
     <dimen name="toolbar_icon_touch_size">50dp</dimen>
     <dimen name="toolbar_icon_padding">14dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">20dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">24dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">24dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">14dp</dimen>
     <dimen name="music_search_container_height">56dp</dimen>
     <dimen name="music_search_field_height">46dp</dimen>
     <dimen name="music_search_list_safe_gap">2dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">6dp</dimen>
     <dimen name="btn_height">50dp</dimen>
     <dimen name="toolbar_height">60dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">20dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">12dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">34dp</dimen>
     <dimen name="toolbar_icon_touch_size">52dp</dimen>
     <dimen name="toolbar_icon_padding">15dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">25dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">30dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">24dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">16dp</dimen>
     <dimen name="music_search_container_height">60dp</dimen>
     <dimen name="music_search_field_height">48dp</dimen>
     <dimen name="music_search_list_safe_gap">6dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">6dp</dimen>
     <dimen name="btn_height">52dp</dimen>
     <dimen name="toolbar_height">62dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">20dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">14dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">6dp</dimen>
     <dimen name="btn_height">56dp</dimen>
     <dimen name="toolbar_height">66dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">22dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">16dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">36dp</dimen>
     <dimen name="toolbar_icon_touch_size">56dp</dimen>
     <dimen name="toolbar_icon_padding">15dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">30dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">36dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">26dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">18dp</dimen>
     <dimen name="music_search_container_height">68dp</dimen>
     <dimen name="music_search_field_height">52dp</dimen>
     <dimen name="music_search_list_safe_gap">18dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">6dp</dimen>
     <dimen name="btn_height">58dp</dimen>
     <dimen name="toolbar_height">70dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">24dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">16dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">38dp</dimen>
     <dimen name="toolbar_icon_touch_size">62dp</dimen>
     <dimen name="toolbar_icon_padding">16dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">35dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">42dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">28dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">20dp</dimen>
     <dimen name="music_search_container_height">68dp</dimen>
     <dimen name="music_search_field_height">52dp</dimen>
     <dimen name="music_search_list_safe_gap">20dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">32dp</dimen>
     <dimen name="toolbar_icon_touch_size">48dp</dimen>
     <dimen name="toolbar_icon_padding">14dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">22dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">12dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">22dp</dimen> <!-- music_list_item_card_content_padding + music_list_item_album_art_margin_start -->
+    <dimen name="music_search_horizontal_inset_end">12dp</dimen> <!-- music_list_item_card_content_padding + music_list_item_end_inset -->
     <dimen name="music_search_container_height">52dp</dimen>
     <dimen name="music_search_field_height">44dp</dimen>
     <dimen name="music_search_list_safe_gap">0dp</dimen>
@@ -37,7 +37,7 @@
     <dimen name="music_search_clear_button_padding">5dp</dimen>
     <dimen name="btn_height">48dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
-    <dimen name="card_padding">4dp</dimen>
+    <dimen name="music_list_item_card_content_padding">4dp</dimen> <!-- 카드 바깥 경계와 실제 자식 레이아웃 사이의 inset -->
     <dimen name="music_list_item_album_art_margin_vertical">4dp</dimen>
     <dimen name="music_list_item_album_art_margin_start">18dp</dimen>
     <dimen name="music_list_item_favorite_icon_size">12dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -27,8 +27,8 @@
     <dimen name="icon_lg">32dp</dimen>
     <dimen name="toolbar_icon_touch_size">48dp</dimen>
     <dimen name="toolbar_icon_padding">14dp</dimen>
-    <dimen name="music_search_horizontal_inset_start">15dp</dimen>
-    <dimen name="music_search_horizontal_inset_end">18dp</dimen>
+    <dimen name="music_search_horizontal_inset_start">22dp</dimen>
+    <dimen name="music_search_horizontal_inset_end">12dp</dimen>
     <dimen name="music_search_container_height">52dp</dimen>
     <dimen name="music_search_field_height">44dp</dimen>
     <dimen name="music_search_list_safe_gap">0dp</dimen>


### PR DESCRIPTION
# PR 내용
1. 검색 창의 좌우 margin을 음악 목록/즐겨찾기 목록 아이템의 좌우 margin과 동일하게 맞추기 위해 dimen 값 조정
  - ` music_search_horizontal_inset_start`를 music_list_item_card_content_padding + music_list_item_album_art_margin_start 값으로 조정
  - `music_search_horizontal_inset_end`를 music_list_item_card_content_padding + music_list_item_end_inset 값으로 조정
  - `music_search_horizontal_inset_start`와 `music_search_horizontal_inset_end`에 관한 주석 추가

2. `card_padding` dimen 속성 이름을 `music_list_item_card_content_padding`으로 변경