### PR TITLE
[ Feature ] 재생 큐 출처 분리 및 제거된 음악 트랙을 대체하는 재생 기능 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/database/music/entity/PlayerModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/database/music/entity/PlayerModel.kt
@@ -14,13 +14,13 @@ data class PlayerModel (
     }
 
     fun updateCurrentMusic(musicModel: MusicModel) {
-//        어차피 id 값이 인덱스 값이다.
+        // 어차피 id 값이 인덱스 값이다.
         currentMusic = musicModel
     }
 
-    fun changedMusic(newMusicKey: String) {
+    fun changedMusic(newMusicId: String) {
         val newMusic = playMusicList.find {
-            it.id == newMusicKey
+            it.id == newMusicId
         }
 
         if (newMusic != null) {
@@ -28,16 +28,13 @@ data class PlayerModel (
         }
     }
 
+    fun clearCurrentMusic() {
+        currentMusic = null
+    }
+
     companion object {
         private var instance: PlayerModel? = null
 
-//        fun getInstance(): PlayerModel {
-//            if (instance == null) {
-//                instance = PlayerModel()
-//            }
-//
-//            return instance as PlayerModel
-//        }
         fun getInstance(): PlayerModel = instance
             ?: PlayerModel().apply { instance = this }
     }

--- a/app/src/main/java/com/hero/ziggymusic/ext/PlayMusicExt.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ext/PlayMusicExt.kt
@@ -1,11 +1,18 @@
 package com.hero.ziggymusic.ext
 
 import android.content.Context
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.view.main.MainActivity
 import dagger.hilt.android.internal.managers.FragmentComponentManager
 
-fun Context.playMusic(musicId: String) {
+fun Context.playMusic(
+    id: String,
+    queueSource: PlaybackQueueSource = PlaybackQueueSource.MUSIC_LIST
+) {
     val activity = FragmentComponentManager.findActivity(this)
 
-    (activity as? MainActivity)?.playMusic(musicId)
+    (activity as? MainActivity)?.playMusic(
+        id = id,
+        queueSource = queueSource
+    )
 }

--- a/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueManager.kt
@@ -42,61 +42,90 @@ class PlaybackQueueManager @Inject constructor(
     }
 
     @OptIn(UnstableApi::class)
-    fun syncQueue(musicList: List<MusicModel>) {
+    fun syncQueue(musicList: List<MusicModel>): PlaybackQueueSyncResult {
+        // 큐를 갱신하기 전에 현재 곡과 재생 상태를 저장해 삭제 후에도 자연스럽게 이어간다.
+        val previousMediaIds = player.currentMediaIds()
+        val previousMediaId = player.currentMediaItem?.mediaId
+        val removedMediaIndex = previousMediaIds.indexOf(previousMediaId)
+        val wasPlaying = player.isPlaying || player.playWhenReady
+
         if (musicList.isEmpty()) {
             // 재생 가능한 음원이 없으면 기존 큐를 정리하여 삭제된 항목이 남지 않게 한다.
             if (player.mediaItemCount > 0) {
                 player.pause()
                 player.clearMediaItems()
+
+                return PlaybackQueueSyncResult(
+                    selectedMediaId = null,
+                    queueChanged = true
+                )
             }
-            return
+
+            return PlaybackQueueSyncResult(
+                selectedMediaId = null,
+                queueChanged = false
+            )
         }
 
         val latestMediaIds = musicList.map { it.id }
-        val currentMediaIds = player.currentMediaIds()
 
-        if (currentMediaIds == latestMediaIds) return
-
-        // 큐를 다시 구성하기 전에 현재 재생 상태를 저장해 복원 여부를 판단한다.
-        val currentMediaId = player.currentMediaItem?.mediaId
-
-        val currentItemStillExists = currentMediaId != null && latestMediaIds.contains(currentMediaId)
-
-        if (currentItemStillExists && canUpdateQueue(currentMediaIds, latestMediaIds)) {
-            updateQueue(
-                currentMediaIds = currentMediaIds,
-                latestMusicList = musicList
+        if (previousMediaIds == latestMediaIds) {
+            return PlaybackQueueSyncResult(
+                selectedMediaId = previousMediaId,
+                queueChanged = false
             )
-            return
         }
 
-        val currentPositionMs = player.currentPosition.coerceAtLeast(0L)
-        val wasPlaying = player.isPlaying
+        val currentItemStillExists =
+            previousMediaId != null && previousMediaId in latestMediaIds
 
-        val restoredIndex = currentMediaId
+        if (currentItemStillExists && canUpdateQueue(previousMediaIds, latestMediaIds)) {
+            updateQueue(
+                currentMediaIds = previousMediaIds,
+                latestMusicList = musicList
+            )
+
+            return PlaybackQueueSyncResult(
+                selectedMediaId = previousMediaId,
+                queueChanged = true
+            )
+        }
+
+        val restoredIndex = previousMediaId
             ?.let { mediaId -> musicList.indexOfFirst { it.id == mediaId } }
             ?.takeIf { it >= 0 }
 
-        val targetIndex = restoredIndex ?: 0
+        // 현재 곡이 삭제된 경우 같은 위치의 다음 곡을, 마지막 곡이었다면 이전 곡을 선택한다.
+        val replacementIndex = removedMediaIndex
+            .takeIf { it >= 0 }
+            ?.coerceAtMost(musicList.lastIndex)
+            ?: 0
+
+        val targetIndex = restoredIndex ?: replacementIndex
         val targetPositionMs = if (restoredIndex != null) {
-            currentPositionMs
+            player.currentPosition.coerceAtLeast(0L)
         } else {
             // 현재 곡이 목록에서 사라졌다면 다른 곡의 중간 위치로 복원하지 않는다.
             0L
         }
 
-        val shouldResumePlayback = wasPlaying && restoredIndex != null
-
         val mediaSources = musicList.map { music ->
             music.toProgressiveMediaSource(context)
         }
 
+        // 큐 재구성 중 의도치 않은 자동 재생을 막고, 저장한 상태에 따라 재생을 복원한다.
+        player.playWhenReady = false
         player.setMediaSources(mediaSources, targetIndex, targetPositionMs)
         player.prepare()
 
-        if (shouldResumePlayback) {
+        if (wasPlaying) {
             player.play()
         }
+
+        return PlaybackQueueSyncResult(
+            selectedMediaId = musicList.getOrNull(targetIndex)?.id,
+            queueChanged = true
+        )
     }
 
     // 현재 재생 중인 곡을 유지할 수 있고 기존 곡들의 상대적인 순서가 바뀌지 않았다면
@@ -144,16 +173,16 @@ class PlaybackQueueManager @Inject constructor(
 
     fun playMusic(
         musicList: List<MusicModel>,
-        musicId: String
+        id: String
     ): Boolean {
         // 요청한 musicId가 현재 재생 가능한 음악 목록에 없으면 실패로 처리한다
-        if (musicList.none { it.id == musicId }) return false
+        if (musicList.none { it.id == id }) return false
 
         // 유효한 재생 요청일 때만 큐를 동기화한다.
         syncQueue(musicList)
 
         // 큐 동기화 이후 실제 Player 큐에서 선택한 곡의 위치를 다시 찾는다.
-        val targetIndex = player.findMediaItemIndexById(musicId)
+        val targetIndex = player.findMediaItemIndexById(id)
         if (targetIndex == -1) return false
 
         player.seekTo(targetIndex, 0L)

--- a/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueSource.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueSource.kt
@@ -1,0 +1,9 @@
+package com.hero.ziggymusic.playback
+
+/*
+** 재생을 시작한 목록을 구분해 이후 큐 동기화에도 같은 출처를 사용한다.
+*/
+enum class PlaybackQueueSource {
+    MUSIC_LIST,
+    FAVORITES
+}

--- a/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueSyncResult.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/PlaybackQueueSyncResult.kt
@@ -1,0 +1,6 @@
+package com.hero.ziggymusic.playback
+
+data class PlaybackQueueSyncResult(
+    val selectedMediaId: String?,
+    val queueChanged: Boolean
+)

--- a/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/MainActivity.kt
@@ -39,6 +39,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.doOnPreDraw
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.service.MusicService
 import com.hero.ziggymusic.service.MusicServiceController
 import com.hero.ziggymusic.view.main.model.MainTitle
@@ -229,9 +230,15 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         }
     }
 
-    fun playMusic(musicId: String) {
+    fun playMusic(
+        id: String,
+        queueSource: PlaybackQueueSource = PlaybackQueueSource.MUSIC_LIST
+    ) {
         // 요청한 음악으로 실제 재생 전환이 성공했을 때만 이후 처리를 계속한다는 가드 역할
-        val changedMusic = playerController.changeMusic(musicId)
+        val changedMusic = playerController.changeMusic(
+            id = id,
+            queueSource = queueSource
+        )
 
         if (!changedMusic) {
             return
@@ -240,7 +247,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         MusicServiceController.dispatchAction(
             context = this,
             action = MusicService.ACTION_REFRESH_NOTIFICATION,
-            mediaId = musicId
+            mediaId = id
         )
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/PlayerController.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.view.main.player.PlayerFragment
 
 class PlayerController(
@@ -54,7 +55,13 @@ class PlayerController(
         }
     }
 
-    fun changeMusic(musicId: String): Boolean {
-        return playerFragment?.changeMusic(musicId) ?: false
+    fun changeMusic(
+        id: String,
+        queueSource: PlaybackQueueSource
+    ): Boolean {
+        return playerFragment?.changeMusic(
+            id = id,
+            queueSource = queueSource
+        ) ?: false
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/favorites/FavoritesFragment.kt
@@ -14,6 +14,7 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.databinding.FragmentFavoritesBinding
 import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.ext.playMusic
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.view.main.popup.MusicOptionMenuPopup
 import com.hero.ziggymusic.view.main.favorites.viewmodel.FavoritesUiState
 import com.hero.ziggymusic.view.main.favorites.viewmodel.FavoritesViewModel
@@ -96,8 +97,11 @@ class FavoritesFragment : Fragment() {
         }
     }
 
-    private fun playMusic(musicKey: String) {
-        requireContext().playMusic(musicKey)
+    private fun playMusic(id: String) {
+        requireContext().playMusic(
+            id = id,
+            queueSource = PlaybackQueueSource.FAVORITES
+        )
     }
 
     private fun openMusicOptionMenuPopup(music: MusicModel, anchorView: View) {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/musiclist/MusicListFragment.kt
@@ -33,6 +33,7 @@ import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.databinding.FragmentMusicListBinding
 import com.hero.ziggymusic.event.EventBus
 import com.hero.ziggymusic.ext.playMusic
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.view.main.popup.MusicOptionMenuPopup
 import com.hero.ziggymusic.view.main.musiclist.viewmodel.MusicSearchResult
 import com.hero.ziggymusic.view.main.musiclist.viewmodel.MusicListUiState
@@ -532,8 +533,11 @@ class MusicListFragment : Fragment() {
         }
     }
 
-    private fun playMusic(musicKey: String) {
-        requireContext().playMusic(musicKey)
+    private fun playMusic(id: String) {
+        requireContext().playMusic(
+            id = id,
+            queueSource = PlaybackQueueSource.MUSIC_LIST
+        )
     }
 
     private fun openMusicOptionMenuPopup(music: MusicModel, anchorView: View) {

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -50,6 +50,7 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.hero.ziggymusic.playback.PlaybackQueueManager
+import com.hero.ziggymusic.playback.PlaybackQueueSource
 import com.hero.ziggymusic.playback.currentPlaybackProgress
 import com.hero.ziggymusic.playback.playbackProgressUpdates
 import com.hero.ziggymusic.service.MusicMediaControllerConnector
@@ -67,6 +68,9 @@ class PlayerFragment : Fragment() {
     private var playerModel: PlayerModel = PlayerModel.getInstance()
     private val vm by activityViewModels<PlayerViewModel>()
     private var playerListener: Player.Listener? = null
+
+    // 사용자가 마지막으로 선택한 목록 기준으로 재생 큐를 유지한다.
+    private var currentQueueSource: PlaybackQueueSource = PlaybackQueueSource.MUSIC_LIST
 
     @Inject
     lateinit var player: ExoPlayer
@@ -273,29 +277,14 @@ class PlayerFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             vm.musicList.observe(viewLifecycleOwner) { musicList ->
-                if (_binding == null) return@observe
-                if (musicList.isEmpty()) return@observe
-
-                playerModel.replaceMusicList(musicList)
-
-                // 현재 ExoPlayer가 재생 중인 곡의 id를 우선 사용
-                val currentMediaId = player.currentMediaItem?.mediaId
-                val nowMusic = musicList.find { it.id == currentMediaId }
-                    ?: musicList.find { it.id == musicKey }
-                    ?: musicList.getOrNull(0)
-
-                // PlayerModel과 UI를 동기화
-                if (nowMusic != null) {
-                    playerModel.updateCurrentMusic(nowMusic)
-                    updatePlayerView(nowMusic)
+                if (currentQueueSource == PlaybackQueueSource.MUSIC_LIST) {
+                    syncPlaybackQueue(musicList)
                 }
+            }
 
-                // 이미 재생 중인 곡이 있으면 playMusic을 다시 호출하지 않는다.
-                if (player.currentMediaItem == null && nowMusic != null) {
-                    playMusic(musicList, nowMusic)
-                } else {
-                    // 목록이 변경되면 현재 재생 상태를 유지한 채 Player 큐만 최신 목록으로 맞춘다.
-                    playbackQueueManager.syncQueue(musicList)
+            vm.availableFavoriteMusicList.observe(viewLifecycleOwner) { favoriteMusicList ->
+                if (currentQueueSource == PlaybackQueueSource.FAVORITES) {
+                    syncPlaybackQueue(favoriteMusicList)
                 }
             }
         }
@@ -307,6 +296,44 @@ class PlayerFragment : Fragment() {
                 updatePlayerView(music)
             }
         }
+    }
+
+    // 현재 큐 출처에 맞춰 Player 큐와 화면에 표시되는 곡 정보를 함께 동기화한다.
+    private fun syncPlaybackQueue(musicList: List<MusicModel>) {
+        if (_binding == null) return
+
+        playerModel.replaceMusicList(musicList)
+
+        if (musicList.isEmpty()) {
+            playbackQueueManager.syncQueue(musicList)
+            playerModel.clearCurrentMusic()
+            updatePlayerView(null)
+            syncPlayerUi()
+            return
+        }
+
+        if (player.currentMediaItem == null) {
+            val initialMusic = musicList.find { it.id == musicKey }
+                ?: musicList.firstOrNull()
+
+            playMusic(musicList, initialMusic)
+            return
+        }
+
+        val syncResult = playbackQueueManager.syncQueue(musicList)
+        val selectedMusic = syncResult.selectedMediaId
+            ?.let { mediaId -> musicList.find { it.id == mediaId } }
+
+        // PlayerModel과 UI를 동기화
+        if (selectedMusic != null) {
+            playerModel.updateCurrentMusic(selectedMusic)
+            updatePlayerView(selectedMusic)
+        } else {
+            playerModel.clearCurrentMusic()
+            updatePlayerView(null)
+        }
+
+        syncPlayerUi()
     }
 
     /**
@@ -339,18 +366,27 @@ class PlayerFragment : Fragment() {
         }
     }
 
-    fun changeMusic(musicId: String): Boolean {
-        val latestMusicList = vm.musicList.value.orEmpty()
+    fun changeMusic(
+        id: String,
+        queueSource: PlaybackQueueSource
+    ): Boolean {
+        currentQueueSource = queueSource
+
+        val latestMusicList = when (queueSource) {
+            PlaybackQueueSource.MUSIC_LIST -> vm.musicList.value.orEmpty()
+            PlaybackQueueSource.FAVORITES -> vm.availableFavoriteMusicList.value.orEmpty()
+        }
 
         // 재생 요청 전에 큐를 최신 목록으로 동기화하여 새로 추가된 음원도 바로 재생되게 한다.
         val startedPlayback = playbackQueueManager.playMusic(
             musicList = latestMusicList,
-            musicId = musicId
+            id = id
         )
 
         if (!startedPlayback) return false
 
-        playerModel.changedMusic(musicId)
+        playerModel.replaceMusicList(latestMusicList)
+        playerModel.changedMusic(id)
         playerModel.currentMusic?.let { music ->
             updatePlayerView(music)
         }

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/PlayerFragment.kt
@@ -78,7 +78,6 @@ class PlayerFragment : Fragment() {
     @Inject
     lateinit var playbackQueueManager: PlaybackQueueManager
 
-    private var currentMusic: MusicModel? = null // 현재 재생 중인 음원
     private val playbackStateStore by lazy { PlaybackStateStore(requireContext()) }
     private var visualizerBarColor: Int? = null
 
@@ -1090,12 +1089,6 @@ class PlayerFragment : Fragment() {
     companion object {
         const val TAG = "PlayerFragment"
         const val EXTRA_MUSIC_FILE_ID: String = "id"
-
-        // 재생 시간 계산의 기본 단위
-        private const val ONE_SECOND_MS = 1_000L
-
-        // 시간 텍스트 표시를 초 경계에 가깝게 맞추기 위한 보정값
-        private const val POSITION_DISPLAY_OFFSET_MS = 80L
 
         private const val PLAYER_TEXT_MARQUEE_START_DELAY_MS = 700L
 

--- a/app/src/main/java/com/hero/ziggymusic/view/main/player/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/view/main/player/viewmodel/PlayerViewModel.kt
@@ -1,6 +1,7 @@
 package com.hero.ziggymusic.view.main.player.viewmodel
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import com.hero.ziggymusic.database.music.entity.MusicModel
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
@@ -20,6 +21,29 @@ class PlayerViewModel @Inject constructor(
     val motionState: StateFlow<PlayerMotionManager.State> = _motionState.asStateFlow()
 
     val musicList: LiveData<List<MusicModel>> = musicRepository.getAllMusic()
+
+    private val favoriteMusicList: LiveData<List<MusicModel>> =
+        musicRepository.getFavorites()
+
+    // 실제 파일이 남아 있는 즐겨찾기만 재생 큐에 사용한다.
+    val availableFavoriteMusicList: LiveData<List<MusicModel>> =
+        MediatorLiveData<List<MusicModel>>().apply {
+            fun updateAvailableFavorites() {
+                val favorites = favoriteMusicList.value ?: return
+                val allMusic = musicList.value ?: return
+                val availableIds = allMusic.mapTo(mutableSetOf()) { it.id }
+
+                value = favorites.filter { it.id in availableIds }
+            }
+
+            addSource(favoriteMusicList) {
+                updateAvailableFavorites()
+            }
+
+            addSource(musicList) {
+                updateAvailableFavorites()
+            }
+        }
 
     fun changeState(toggleState: PlayerMotionManager.State) {
         _motionState.value = toggleState


### PR DESCRIPTION
# PR 내용
1. 제거된 현재 재생 트랙 처리 개선
  - 재생 중인 음악 파일이 목록에서 사라졌을 때 첫 곡으로 이동하지 않고 삭제된 위치 기준의 다음 곡으로 이동하도록 변경
  - 삭제된 곡이 마지막 곡이면 이전 곡으로 이동하고, 남은 곡이 없으면 큐와 현재 곡 상태를 정리

2. 재생 큐 출처 분리
  - 음악 목록과 즐겨찾기에서 재생을 시작한 출처를 PlaybackQueueSource로 구분
  - 즐겨찾기에서 재생 중인 곡이 삭제되어도 전체 음악 목록이 아닌 즐겨찾기 큐 기준으로 동기화

3. 플레이어 상태 및 UI 동기화 보완
  - 큐 동기화 결과로 선택된 mediaId를 반환해 PlayerModel과 플레이어 UI를 함께 갱신
  - 실제 파일이 남아 있는 즐겨찾기만 재생 큐에 사용하도록 availableFavoriteMusicList 추가