### PR TITLE
[ UI/UX ] 음향 효과 바텀시트 추가 및 설정 화면 이동 연동

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -216,9 +216,14 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             return
         }
 
-        val appSettingsFragment =
-            supportFragmentManager.findFragmentByTag(TAG_APP_SETTINGS)
-                ?: return
+        var appSettingsFragment = supportFragmentManager.findFragmentByTag(TAG_APP_SETTINGS)
+
+        if (appSettingsFragment == null) {
+            showAppSettingsFragment()
+            supportFragmentManager.executePendingTransactions()
+
+            appSettingsFragment = supportFragmentManager.findFragmentByTag(TAG_APP_SETTINGS) ?: return
+        }
 
         val audioSettingsFragment =
             existingAudioSettingsFragment ?: AudioSettingsFragment.newInstance()

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/PlayerFragment.kt
@@ -62,6 +62,8 @@ import com.hero.ziggymusic.presentation.main.player.manager.PlayerMotionManager
 import com.hero.ziggymusic.playback.service.MusicMediaControllerConnector
 import com.hero.ziggymusic.playback.service.MusicServiceController
 import com.hero.ziggymusic.playback.model.LastPlayedMedia
+import com.hero.ziggymusic.presentation.main.MainViewModel
+import com.hero.ziggymusic.presentation.main.player.audioeffect.AudioEffectBottomSheetDialogFragment
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import java.util.Locale
@@ -73,6 +75,7 @@ class PlayerFragment : Fragment() {
 
     private var playerStateHolder: PlayerStateHolder = PlayerStateHolder.getInstance()
     private val vm by activityViewModels<PlayerViewModel>()
+    private val mainVm by activityViewModels<MainViewModel>()
     private var playerListener: Player.Listener? = null
 
     // 사용자가 마지막으로 선택한 목록 기준으로 재생 큐를 유지한다.
@@ -86,6 +89,7 @@ class PlayerFragment : Fragment() {
 
     private val lastPlaybackStore by lazy { LastPlaybackStore(requireContext()) }
     private var visualizerBarColor: Int? = null
+    private var pendingAudioSettingsNavigation = false // 바텀시트 액션을 받은 뒤 플레이어가 collapsed 상태가 될 때까지 음향 설정 화면으로 이동하기 위한 대기 상태.
 
     // position 저장 쓰로틀링으로 불필요한 prefs write를 줄인다.
     private var lastSavedAtMs: Long = 0L
@@ -137,6 +141,7 @@ class PlayerFragment : Fragment() {
         initPlayControlButtons()
         initSeekBar()
         initPlayerManager()
+        initAudioEffectBottomSheetResult()
         initViewModel()
         observePlaybackProgress()
         initListeners()
@@ -182,6 +187,13 @@ class PlayerFragment : Fragment() {
             }
         }
 
+        binding.playbackVisualizerView.setOnClickListener {
+            AudioEffectBottomSheetDialogFragment.newInstance().show(
+                childFragmentManager,
+                AudioEffectBottomSheetDialogFragment.TAG
+            )
+        }
+
         binding.bluetooth.setOnClickListener {
             playerBluetoothManager.handleBluetoothClick()
         }
@@ -189,6 +201,42 @@ class PlayerFragment : Fragment() {
         toggleVolumeIcon()
         toggleRepeatModeIcon()
         toggleShuffleModeIcon()
+    }
+
+    // 음향 효과 바텀시트에서 전달한 일회성 액션을 수신한다.
+    // 바텀시트를 childFragmentManager로 띄우므로 동일한 manager에 listener를 등록한다.
+    private fun initAudioEffectBottomSheetResult() {
+        childFragmentManager.setFragmentResultListener(
+            AudioEffectBottomSheetDialogFragment.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, bundle ->
+            when (bundle.getString(AudioEffectBottomSheetDialogFragment.RESULT_ACTION_KEY)) {
+                AudioEffectBottomSheetDialogFragment.ACTION_OPEN_AUDIO_SETTINGS -> {
+                    requestOpenAudioSettingsAfterCollapse()
+                }
+            }
+        }
+    }
+
+    // 음향 효과 설정 화면이 바로 보이도록 플레이어를 먼저 collapsed 상태로 전환한다.
+    private fun requestOpenAudioSettingsAfterCollapse() {
+        pendingAudioSettingsNavigation = true
+
+        if (vm.motionState.value == PlayerMotionManager.State.COLLAPSED) {
+            openAudioSettingsIfPending()
+        } else {
+            playerBottomSheetManager.collapse()
+        }
+    }
+
+    // collapsed 전환이 끝난 뒤 대기 중인 음향 효과 설정 화면으로 한 번 더 이동한다.
+    private fun openAudioSettingsIfPending() {
+        if (!pendingAudioSettingsNavigation) {
+            return
+        }
+
+        pendingAudioSettingsNavigation = false
+        mainVm.requestOpenAudioSettings()
     }
 
     private fun initPlayerManager() {
@@ -204,6 +252,7 @@ class PlayerFragment : Fragment() {
 
                         BottomSheetBehavior.STATE_COLLAPSED -> {
                             vm.changeState(PlayerMotionManager.State.COLLAPSED)
+                            openAudioSettingsIfPending()
                         }
 
                         BottomSheetBehavior.STATE_HIDDEN -> {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -1,0 +1,272 @@
+package com.hero.ziggymusic.presentation.main.player.audioeffect
+
+import android.app.Dialog
+import android.content.Context
+import android.content.SharedPreferences
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.SeekBar
+import androidx.core.content.edit
+import androidx.core.graphics.drawable.toDrawable
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.hero.ziggymusic.R
+import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
+import com.hero.ziggymusic.databinding.FragmentAudioEffectBottomSheetBinding
+import com.hero.ziggymusic.playback.manager.AudioEffectManager
+import com.hero.ziggymusic.presentation.main.setting.AudioSettingsFragment
+
+class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentAudioEffectBottomSheetBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var prefs: SharedPreferences
+
+    private val recentPresetButtonIds = listOf(
+        R.id.btnRecentPresetFirst,
+        R.id.btnRecentPresetSecond,
+        R.id.btnRecentPresetThird,
+        R.id.btnRecentPresetFourth,
+    )
+
+    private val recentPresets = listOf(
+        AudioEffectPreset.NORMAL,
+        AudioEffectPreset.POP,
+        AudioEffectPreset.ROCK,
+        AudioEffectPreset.CUSTOM,
+    )
+
+    override fun getTheme(): Int = R.style.PlayerBottomSheet
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return BottomSheetDialog(requireContext(), theme).apply {
+            setOnShowListener {
+                setupBottomSheetBehavior(this)
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentAudioEffectBottomSheetBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        prefs = requireContext().getSharedPreferences(
+            AudioSettingsFragment.TAG,
+            Context.MODE_PRIVATE,
+        )
+
+        setupAudioEffectInitialState()
+        setupPresetControls()
+        setupLoudnessNormalizer()
+        setupAudioEffectSeekBars()
+        setupSettingsNavigation()
+    }
+
+    private fun setupBottomSheetBehavior(dialog: BottomSheetDialog) {
+        val bottomSheet = dialog.findViewById<View>(
+            com.google.android.material.R.id.design_bottom_sheet,
+        ) ?: return
+
+        val maxWidth = resources.getDimensionPixelSize(R.dimen.audio_effect_bottom_sheet_max_width)
+
+        bottomSheet.layoutParams = bottomSheet.layoutParams.apply {
+            width = if (maxWidth > 0) {
+                minOf(resources.displayMetrics.widthPixels, maxWidth)
+            } else {
+                ViewGroup.LayoutParams.MATCH_PARENT
+            }
+        }
+
+        bottomSheet.background = Color.TRANSPARENT.toDrawable()
+
+        BottomSheetBehavior.from(bottomSheet).apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+        }
+    }
+
+    private fun setupAudioEffectInitialState() {
+        binding.swLoudnessNormalizer.isChecked = prefs.getBoolean(
+            AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED,
+            false,
+        )
+
+        binding.seekBarBass.progress = prefs.getInt(
+            AudioSettingKeys.KEY_BASS,
+            DEFAULT_EFFECT_VALUE
+        )
+
+        binding.seekBarVirtualizer.progress = prefs.getInt(
+            AudioSettingKeys.KEY_VIRTUALIZER,
+            DEFAULT_EFFECT_VALUE,
+        )
+    }
+
+    private fun setupPresetControls() {
+        binding.togglePresetGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (!isChecked) return@addOnButtonCheckedListener
+
+            val presetIndex = recentPresetButtonIds.indexOf(checkedId)
+            val preset = recentPresets.getOrNull(presetIndex)
+                ?: return@addOnButtonCheckedListener
+
+            applyAudioEffectPreset(preset)
+        }
+    }
+
+    private fun setupLoudnessNormalizer() {
+        binding.swLoudnessNormalizer.setOnCheckedChangeListener { _, isChecked ->
+            AudioEffectManager.applyLoudnessNormalizer(isChecked, prefs)
+        }
+    }
+
+    private fun setupAudioEffectSeekBars() {
+        binding.seekBarBass.setOnSeekBarChangeListener(
+            createSeekBarChangeListener { progress ->
+                applyBass(progress)
+                saveCustomPresetSelection()
+            },
+        )
+
+        binding.seekBarVirtualizer.setOnSeekBarChangeListener(
+            createSeekBarChangeListener { progress ->
+                applyVirtualizer(progress)
+                saveCustomPresetSelection()
+            },
+        )
+    }
+
+    private fun setupSettingsNavigation() {
+        binding.tvOpenAudioEffectSettings.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply {
+                    putString(RESULT_ACTION_KEY, ACTION_OPEN_AUDIO_SETTINGS)
+                }
+            )
+            dismiss()
+        }
+    }
+
+    private fun applyAudioEffectPreset(preset: AudioEffectPreset) {
+        if (preset == AudioEffectPreset.CUSTOM) {
+            saveCustomPresetSelection()
+            return
+        }
+
+        applyNativeEqualizerPresetIfAvailable(preset)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+    }
+
+    private fun applyNativeEqualizerPresetIfAvailable(preset: AudioEffectPreset) {
+        val nativePresetIndex = findNativeEqualizerPresetIndex(preset)
+
+        if (nativePresetIndex == null) {
+            saveCustomPresetSelection()
+            return
+        }
+
+        AudioEffectManager.useEqualizerPreset(nativePresetIndex)
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_PRESET, nativePresetIndex + SETTINGS_PRESET_OFFSET)
+        }
+    }
+
+    private fun findNativeEqualizerPresetIndex(preset: AudioEffectPreset): Int? {
+        val numberOfPresets = AudioEffectManager.getNumberOfPresets()
+        if (numberOfPresets <= 0) return null
+
+        val candidates = preset.config.equalizerPresetNameCandidates
+
+        return (0 until numberOfPresets).firstOrNull { index ->
+            val presetName = AudioEffectManager.getPresetName(index).orEmpty()
+            candidates.any { candidate ->
+                presetName.equals(candidate, ignoreCase = true)
+            }
+        }
+    }
+
+    private fun applyBass(progress: Int) {
+        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE) // 베이스 보정값
+
+        if (binding.seekBarBass.progress != clampedProgress) {
+            binding.seekBarBass.progress = clampedProgress
+        }
+
+        AudioEffectManager.applyBassStrength(clampedProgress, prefs)
+    }
+
+    private fun applyVirtualizer(progress: Int) {
+        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE) // 3D 버추얼라이저 보정값
+
+        if (binding.seekBarVirtualizer.progress != clampedProgress) {
+            binding.seekBarVirtualizer.progress = clampedProgress
+        }
+
+        AudioEffectManager.applyVirtualizerStrength(clampedProgress, prefs)
+    }
+
+    private fun saveCustomPresetSelection() {
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_PRESET, CUSTOM_PRESET_POSITION)
+        }
+    }
+
+    private fun createSeekBarChangeListener(
+        onProgressChangedByUser: (progress: Int) -> Unit,
+    ): SeekBar.OnSeekBarChangeListener {
+        return object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(
+                seekBar: SeekBar?,
+                progress: Int,
+                fromUser: Boolean,
+            ) {
+                if (fromUser) {
+                    onProgressChangedByUser(progress)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
+    companion object {
+        const val TAG = "AudioEffectBottomSheetDialogFragment"
+
+        // Fragment Result로 PlayerFragment에 전달할 바텀시트 액션 정보.
+        const val REQUEST_KEY = "audio_effect_bottom_sheet_request"
+        const val RESULT_ACTION_KEY = "audio_effect_bottom_sheet_action"
+        const val ACTION_OPEN_AUDIO_SETTINGS = "open_audio_settings"
+
+        // SeekBar 기반 음향 효과 값은 0~100 범위로 통일한다.
+        private const val MIN_EFFECT_VALUE = 0
+        private const val MAX_EFFECT_VALUE = 100
+        private const val DEFAULT_EFFECT_VALUE = 0
+
+        // AudioSettingsFragment의 프리셋 목록은 0번을 Custom으로 사용한다.
+        private const val CUSTOM_PRESET_POSITION = 0
+        private const val SETTINGS_PRESET_OFFSET = 1
+
+        fun newInstance(): AudioEffectBottomSheetDialogFragment =
+            AudioEffectBottomSheetDialogFragment()
+
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -78,16 +78,6 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
             com.google.android.material.R.id.design_bottom_sheet,
         ) ?: return
 
-        val maxWidth = resources.getDimensionPixelSize(R.dimen.audio_effect_bottom_sheet_max_width)
-
-        bottomSheet.layoutParams = bottomSheet.layoutParams.apply {
-            width = if (maxWidth > 0) {
-                minOf(resources.displayMetrics.widthPixels, maxWidth)
-            } else {
-                ViewGroup.LayoutParams.MATCH_PARENT
-            }
-        }
-
         bottomSheet.background = Color.TRANSPARENT.toDrawable()
 
         BottomSheetBehavior.from(bottomSheet).apply {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectPreset.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectPreset.kt
@@ -1,0 +1,109 @@
+package com.hero.ziggymusic.presentation.main.player.audioeffect
+
+import androidx.annotation.StringRes
+import com.hero.ziggymusic.R
+
+/**
+ * 프리셋 선택 시 적용할 음향 효과 값과 네이티브 EQ preset 후보명.
+ *
+ * 기기마다 Equalizer preset 이름이 다를 수 있어 후보명을 함께 관리한다.
+ */
+data class AudioEffectPresetConfig(
+    val settingsPresetPosition: Int,
+    val equalizerPresetNameCandidates: List<String> = emptyList(),
+)
+
+/**
+ * 플레이어 바텀시트에서 빠르게 적용하는 음향 효과 프리셋.
+ *
+ * CUSTOM은 사용자가 직접 조절한 상태를 표시하기 위한 항목이며,
+ * 선택 시 기존 효과 값을 덮어쓰지 않는다.
+ */
+enum class AudioEffectPreset(
+    @param:StringRes val labelResId: Int,
+    val config: AudioEffectPresetConfig,
+) {
+    CUSTOM(
+        labelResId = R.string.preset_custom,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 0,
+        )
+    ),
+
+    NORMAL(
+        labelResId = R.string.preset_normal,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 1,
+        )
+    ),
+
+    CLASSICAL(
+        labelResId = R.string.preset_classical,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 2,
+        )
+    ),
+
+    DANCE(
+        labelResId = R.string.preset_dance,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 3,
+        )
+    ),
+
+    FLAT(
+        labelResId = R.string.preset_flat,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 4,
+            equalizerPresetNameCandidates = listOf("Flat", "Normal"),
+        )
+    ),
+
+    FOLK(
+        labelResId = R.string.preset_folk,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 5,
+            equalizerPresetNameCandidates = listOf("Folk"),
+        )
+    ),
+
+    HEAVY_METAL(
+        labelResId = R.string.preset_heavy_metal,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 6,
+            equalizerPresetNameCandidates = listOf("Heavy Metal"),
+        )
+    ),
+
+    HIP_HOP(
+        labelResId = R.string.preset_hip_hop,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 7,
+            equalizerPresetNameCandidates = listOf("Hip Hop"),
+        )
+    ),
+
+    JAZZ(
+        labelResId = R.string.preset_jazz,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 8,
+            equalizerPresetNameCandidates = listOf("Jazz"),
+        )
+    ),
+
+    POP(
+        labelResId = R.string.preset_pop,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 9,
+            equalizerPresetNameCandidates = listOf("Pop"),
+        )
+    ),
+
+    ROCK(
+        labelResId = R.string.preset_rock,
+        config = AudioEffectPresetConfig(
+            settingsPresetPosition = 10,
+            equalizerPresetNameCandidates = listOf("Rock"),
+        )
+    );
+}

--- a/app/src/main/res/color/audio_effect_preset_button_stroke_color.xml
+++ b/app/src/main/res/color/audio_effect_preset_button_stroke_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/cyan" />
+    <item android:color="@color/audio_effect_bottom_sheet_preset_button_stroke" />
+</selector>

--- a/app/src/main/res/color/audio_effect_preset_button_text_color.xml
+++ b/app/src/main/res/color/audio_effect_preset_button_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/cyan" />
+    <item android:color="@color/white" />
+</selector>

--- a/app/src/main/res/drawable/bg_audio_effect_bottom_sheet.xml
+++ b/app/src/main/res/drawable/bg_audio_effect_bottom_sheet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/audio_effect_bottom_sheet_background" />
+
+    <corners
+        android:topLeftRadius="@dimen/audio_effect_bottom_sheet_corner_radius"
+        android:topRightRadius="@dimen/audio_effect_bottom_sheet_corner_radius" />
+
+    <stroke
+        android:width="1dp"
+        android:color="@color/audio_effect_bottom_sheet_stroke" />
+</shape>

--- a/app/src/main/res/layout/fragment_audio_effect_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_audio_effect_bottom_sheet.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/audioEffectBottomSheet"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_audio_effect_bottom_sheet"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/audio_effect_bottom_sheet_padding_horizontal"
+    android:paddingTop="@dimen/audio_effect_bottom_sheet_padding_top"
+    android:paddingEnd="@dimen/audio_effect_bottom_sheet_padding_horizontal"
+    android:paddingBottom="@dimen/audio_effect_bottom_sheet_padding_bottom">
+
+    <View
+        android:id="@+id/dragHandle"
+        android:layout_width="@dimen/audio_effect_bottom_sheet_handle_width"
+        android:layout_height="@dimen/audio_effect_bottom_sheet_handle_height"
+        android:layout_gravity="center_horizontal"
+        android:background="@drawable/ic_drag_handle" />
+
+    <LinearLayout
+        android:id="@+id/layoutAudioEffectHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_header_margin_top"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/tvAudioEffectTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/audio_effect"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Title" />
+
+        <TextView
+            android:id="@+id/tvOpenAudioEffectSettings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_trailing_alignment_margin"
+            android:text="@string/audio_effect_open_settings"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Action" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tvRecentPresetTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_preset_title_margin_top"
+        android:text="@string/recent_presets"
+        android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.SectionTitle" />
+
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/togglePresetGroup"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/audio_effect_bottom_sheet_preset_button_height"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_preset_group_margin_top"
+        android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_trailing_alignment_margin"
+        app:checkedButton="@id/btnRecentPresetFirst"
+        app:selectionRequired="true"
+        app:singleSelection="true">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnRecentPresetFirst"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_preset_button_gap"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:text="@string/preset_normal"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Preset"
+            android:textColor="@color/audio_effect_preset_button_text_color"
+            app:cornerRadius="@dimen/audio_effect_bottom_sheet_preset_button_radius"
+            app:strokeColor="@color/audio_effect_preset_button_stroke_color"
+            app:strokeWidth="@dimen/audio_effect_bottom_sheet_preset_button_stroke_width" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnRecentPresetSecond"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginHorizontal="@dimen/audio_effect_bottom_sheet_preset_button_gap"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:text="@string/preset_pop"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Preset"
+            android:textColor="@color/audio_effect_preset_button_text_color"
+            app:cornerRadius="@dimen/audio_effect_bottom_sheet_preset_button_radius"
+            app:strokeColor="@color/audio_effect_preset_button_stroke_color"
+            app:strokeWidth="@dimen/audio_effect_bottom_sheet_preset_button_stroke_width" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnRecentPresetThird"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginHorizontal="@dimen/audio_effect_bottom_sheet_preset_button_gap"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:text="@string/preset_rock"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Preset"
+            android:textColor="@color/audio_effect_preset_button_text_color"
+            app:cornerRadius="@dimen/audio_effect_bottom_sheet_preset_button_radius"
+            app:strokeColor="@color/audio_effect_preset_button_stroke_color"
+            app:strokeWidth="@dimen/audio_effect_bottom_sheet_preset_button_stroke_width" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnRecentPresetFourth"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="@dimen/audio_effect_bottom_sheet_preset_button_gap"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:paddingTop="0dp"
+            android:paddingBottom="0dp"
+            android:text="@string/preset_custom"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Preset"
+            android:textColor="@color/audio_effect_preset_button_text_color"
+            app:cornerRadius="@dimen/audio_effect_bottom_sheet_preset_button_radius"
+            app:strokeColor="@color/audio_effect_preset_button_stroke_color"
+            app:strokeWidth="@dimen/audio_effect_bottom_sheet_preset_button_stroke_width" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layoutLoudnessNormalizer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_loudness_margin_top">
+
+        <LinearLayout
+            android:id="@+id/layoutLoudnessText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/swLoudnessNormalizer"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tvLoudnessNormalizerTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/loudness_normalizer"
+                android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.SectionTitle" />
+
+            <TextView
+                android:id="@+id/tvLoudnessNormalizerDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/audio_effect_bottom_sheet_description_margin_top"
+                android:text="@string/loudness_normalizer_description"
+                android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.Description" />
+
+        </LinearLayout>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/swLoudnessNormalizer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/loudness_normalizer"
+            android:minWidth="0dp"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:switchMinWidth="0dp"
+            app:switchPadding="0dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layoutBass"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/audio_effect_bottom_sheet_seekbar_row_height"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_seekbar_row_margin_top">
+
+        <TextView
+            android:id="@+id/tvBassTitle"
+            android:layout_width="@dimen/audio_effect_bottom_sheet_bass_label_width"
+            android:layout_height="wrap_content"
+            android:text="@string/bass"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.ControlLabel"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <SeekBar
+            android:id="@+id/seekBarBass"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/audio_effect_bottom_sheet_label_to_seekbar_gap"
+            android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_seekbar_end_adjustment"
+            android:max="100"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tvBassTitle"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layoutVirtualizer"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/audio_effect_bottom_sheet_seekbar_row_height"
+        android:layout_marginTop="@dimen/audio_effect_bottom_sheet_virtualizer_margin_top">
+
+        <TextView
+            android:id="@+id/tvVirtualizerTitle"
+            android:layout_width="@dimen/audio_effect_bottom_sheet_virtualizer_label_width"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/_3d_virtualizer"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.AudioEffect.ControlLabel"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <SeekBar
+            android:id="@+id/seekBarVirtualizer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/audio_effect_bottom_sheet_label_to_seekbar_gap"
+            android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_seekbar_end_adjustment"
+            android:max="100"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tvVirtualizerTitle"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_audio_effect_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_audio_effect_bottom_sheet.xml
@@ -185,6 +185,7 @@
             android:id="@+id/swLoudnessNormalizer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/audio_effect_bottom_sheet_switch_end_adjustment"
             android:contentDescription="@string/loudness_normalizer"
             android:minWidth="0dp"
             android:paddingStart="0dp"

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -130,6 +130,27 @@
     <dimen name="app_settings_chevron_size">22dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">10dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">20dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">32dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">22dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">32dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">6dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_trailing_alignment_margin">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">22dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">22dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">8dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">82dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">118dp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">46dp</dimen>
     <dimen name="noti_extended_height">120dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -130,6 +130,26 @@
     <dimen name="app_settings_chevron_size">24dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">12dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">9dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">9dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">96dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">128dp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">48dp</dimen>
     <dimen name="noti_extended_height">130dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -130,6 +130,26 @@
     <dimen name="app_settings_chevron_size">24dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">12dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">40dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">34dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">9dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">112dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">152dp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">52dp</dimen>
     <dimen name="noti_extended_height">140dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -130,6 +130,26 @@
     <dimen name="app_settings_chevron_size">26dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">14dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">40dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">26dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">26dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">10dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">16dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">112dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">152dp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">56dp</dimen>
     <dimen name="noti_extended_height">156dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -130,6 +130,26 @@
     <dimen name="app_settings_chevron_size">24dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">16dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">20dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">32dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">16dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">34dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">30dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">16dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">20dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">96dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">176dp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">62dp</dimen>
     <dimen name="noti_extended_height">173dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -109,6 +109,7 @@
     <dimen name="layout_volume_padding">70dp</dimen>
 
     <!-- App Settings -->
+
     <dimen name="app_settings_content_horizontal_inset">48dp</dimen>
     <dimen name="app_settings_content_padding_top">48dp</dimen>
     <dimen name="app_settings_content_padding_bottom">60dp</dimen>
@@ -128,6 +129,28 @@
 
     <dimen name="app_settings_chevron_size">26dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">16dp</dimen>
+
+    <!-- Audio effect bottom sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">26dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">20dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">44dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">18dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">12dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">40dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">32dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">18dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">112dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">184dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_title_text_size">21sp</dimen>
 
     <!-- Notification -->
     <dimen name="noti_height">70dp</dimen>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,13 @@
     <color name="setting_dark_gradient_center">#0D1012</color>
     <color name="setting_dark_gradient_end">#202124</color>
     <color name="setting_divider">#1FFFFFFF</color>
+
+    <!-- Audio effect bottom sheet -->
+    <color name="audio_effect_bottom_sheet_background">#F20F1012</color>
+    <color name="audio_effect_bottom_sheet_stroke">#33FFFFFF</color>
+    <color name="audio_effect_bottom_sheet_preset_button_stroke">#66FFFFFF</color>
+
+
     <color name="bottom_nav_scrim">#CC101214</color>
     <color name="player_collapsed_scrim">#E6101214</color>
     <color name="music_option_menu_popup_background">#F20F1012</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -132,6 +132,43 @@
     <dimen name="app_settings_chevron_size">24dp</dimen>
     <dimen name="app_settings_text_to_trailing_icon_gap">12dp</dimen>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <dimen name="audio_effect_bottom_sheet_padding_horizontal">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_padding_bottom">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_corner_radius">28dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_handle_width">42dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_handle_height">4dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_header_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_title_margin_top">36dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_group_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_height">48dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_gap">9dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_radius">8dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_button_stroke_width">1dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_trailing_alignment_margin">10dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_loudness_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_description_margin_top">10dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_switch_end_adjustment">-2dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_height">48dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_row_margin_top">24dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_seekbar_end_adjustment">-6dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_label_to_seekbar_gap">9dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_margin_top">14dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_bass_label_width">96dp</dimen>
+    <dimen name="audio_effect_bottom_sheet_virtualizer_label_width">128dp</dimen>
+
+    <dimen name="audio_effect_bottom_sheet_description_text_size">13sp</dimen>
+    <dimen name="audio_effect_bottom_sheet_preset_text_size">13sp</dimen>
+    <dimen name="audio_effect_bottom_sheet_action_text_size">15sp</dimen>
+    <dimen name="audio_effect_bottom_sheet_control_label_text_size">15sp</dimen>
+    <dimen name="audio_effect_bottom_sheet_section_text_size">17sp</dimen>
+    <dimen name="audio_effect_bottom_sheet_title_text_size">20sp</dimen>
+
     <!-- Notification -->
     <dimen name="noti_height">48dp</dimen>
     <dimen name="noti_extended_height">130dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="settings_open_source_licenses">오픈소스 라이선스</string>
     <string name="settings_app_version">앱 버전</string>
 
+    <!-- Audio settings -->
     <string name="equalizer">이퀄라이저</string>
     <string name="preset">프리셋</string>
     <string name="eq_max">+12</string>
@@ -49,4 +50,19 @@
     <string name="loudness_normalizer_description">곡마다 다른 음량을 일정하게 맞춤</string>
     <string name="spatial_audio">Spatial Audio</string>
     <string name="head_tracking">Head Tracking</string>
+
+    <!-- Audio effect bottom sheet -->
+    <string name="audio_effect_open_settings">전체 설정</string>
+    <string name="recent_presets">최근 프리셋</string>
+    <string name="preset_normal">Normal</string>
+    <string name="preset_classical">Classical</string>
+    <string name="preset_dance">Dance</string>
+    <string name="preset_flat">Flat</string>
+    <string name="preset_folk">Folk</string>
+    <string name="preset_heavy_metal">Heavy Metal</string>
+    <string name="preset_hip_hop">Hip Hop</string>
+    <string name="preset_jazz">Jazz</string>
+    <string name="preset_pop">Pop</string>
+    <string name="preset_rock">Rock</string>
+    <string name="preset_custom">Custom</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -144,6 +144,33 @@
         <item name="android:textSize">@dimen/small_text_size</item>
     </style>
 
+    <!-- Audio Effect Bottom Sheet -->
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.Title" parent="TextAppearance.ZiggyMusic.White.Title.Bold">
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_title_text_size</item>
+    </style>
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.Action" parent="TextAppearance.ZiggyMusic.White.Body.SemiBold">
+        <item name="android:textColor">@color/cyan</item>
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_action_text_size</item>
+    </style>
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.SectionTitle" parent="TextAppearance.ZiggyMusic.White.Body.SemiBold">
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_section_text_size</item>
+    </style>
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.Description" parent="TextAppearance.ZiggyMusic.Setting.Description">
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_description_text_size</item>
+    </style>
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.ControlLabel" parent="TextAppearance.ZiggyMusic.White.Body.SemiBold">
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_control_label_text_size</item>
+    </style>
+
+    <style name="TextAppearance.ZiggyMusic.AudioEffect.Preset" parent="TextAppearance.ZiggyMusic.White.Body.SemiBold">
+        <item name="android:textSize">@dimen/audio_effect_bottom_sheet_preset_text_size</item>
+    </style>
+
     <style name="TextAppearance.ZiggyMusic.Notification.Title.Small" parent="TextAppearance.Compat.Notification.Title">
         <item name="android:fontFamily">@font/pretendard_semibold</item>
         <item name="fontFamily">@font/pretendard_semibold</item>


### PR DESCRIPTION
# PR 내용

1. 음향 효과 바텀시트 UI 추가
  - 최근 프리셋, 음량 평준화, 베이스, 3D 버추얼라이저 조절 영역을 구성
  - 바텀시트 전용 레이아웃, 배경, 색상 selector, 문자열, TextAppearance 스타일을 추가
  - sw320, sw360, sw400, sw480, sw600, sw720 기준 dimen을 분리해 기기별 크기와 간격을 조정

2. 음향 효과 프리셋 모델 및 적용 로직 추가
  - AudioEffectPreset과 AudioEffectPresetConfig를 추가해 설정 화면의 EQ 프리셋 목록과 매핑
  - 최근 프리셋 버튼을 index 기반으로 연결하고, 선택한 프리셋에 따라 EQ 설정을 적용하도록 구성
  - 베이스와 3D 버추얼라이저 seekbar 값을 보정해 유효 범위 안에서 적용되도록 처리

3. 전체 설정 이동 흐름 연동
  - PlayerFragment에서 비주얼라이저 클릭 시 AudioEffectBottomSheetDialogFragment를 표시하도록 연결
  - Fragment Result로 바텀시트의 전체 설정 클릭 이벤트를 전달하도록 구현
  - 플레이어가 collapsed 상태가 된 뒤 AppSettingsFragment와 AudioSettingsFragment로 이동하도록 MainActivity 이동 로직을 보완