### PR TITLE
[ Feature ] 음향 설정 상태 동기화 및 저장값 로드 처리 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
@@ -1,0 +1,229 @@
+package com.hero.ziggymusic.data.audio.repository
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
+import com.hero.ziggymusic.domain.audio.repository.AudioSettingsRepository
+import com.hero.ziggymusic.playback.manager.AudioEffectManager
+import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioSettingsRepositoryImpl @Inject constructor(
+    @ApplicationContext context: Context,
+) : AudioSettingsRepository {
+    // EQ, BassBoost, Virtualizer, Loudness 설정을 Repository에서 공통 관리한다.
+    private val prefs = context.getSharedPreferences(
+        AudioSettingKeys.PREF_AUDIO_SETTINGS,
+        Context.MODE_PRIVATE,
+    )
+
+    private val _settingsState = MutableStateFlow(loadAudioSettingsState())
+    override val settingsState: StateFlow<AudioSettingsUiState> = _settingsState.asStateFlow()
+
+    override fun refreshSettings() {
+        updateStateFromStorage()
+    }
+
+    // 저장된 설정을 실제 Android AudioEffect와 DSP 체인에 다시 적용한다.
+    override fun applySavedSettings() {
+        val savedAudioSettings = loadAudioSettingsState()
+
+        // 저장된 프리셋이 Custom이 아니면 Android Equalizer 프리셋을 먼저 적용한다.
+        if (savedAudioSettings.currentPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+            AudioEffectManager.useEqualizerPreset(
+                savedAudioSettings.currentPresetPosition - SETTINGS_PRESET_OFFSET
+            )
+        } else {
+            applySavedEqualizerBands()
+        }
+
+        AudioEffectManager.applyBassStrength(savedAudioSettings.bassStrength)
+        AudioEffectManager.applyVirtualizerStrength(savedAudioSettings.virtualizerStrength)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
+    override fun setEqualizerEnabled(enabled: Boolean) {
+        if (loadAudioSettingsState().isEqualizerEnabled != enabled) {
+            prefs.edit {
+                putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, enabled)
+            }
+        }
+
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+        updateStateFromStorage()
+    }
+
+    // 프리셋 선택은 EQ 사용 의도가 명확하므로 EQ를 자동으로 켠다.
+    override fun setEqualizerPreset(presetPosition: Int) {
+        val normalizedPresetPosition = presetPosition.coerceAtLeast(
+            AudioSettingsUiState.CUSTOM_PRESET_POSITION,
+        )
+
+        prefs.edit {
+            putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
+            putInt(AudioSettingKeys.KEY_PRESET, normalizedPresetPosition)
+        }
+
+        if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+            AudioEffectManager.useEqualizerPreset(normalizedPresetPosition - SETTINGS_PRESET_OFFSET)
+        }
+
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+        updateStateFromStorage()
+    }
+
+    // Custom은 저장된 EQ 밴드 값을 다시 적용하는 프리셋으로 취급한다.
+    override fun setCustomEqualizerPreset() {
+        prefs.edit {
+            putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
+            putInt(AudioSettingKeys.KEY_PRESET, AudioSettingsUiState.CUSTOM_PRESET_POSITION)
+        }
+
+        applySavedEqualizerBands()
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
+    // 저장된 EQ 밴드 progress를 실제 Equalizer와 DSP EQ 값으로 복원한다.
+    private fun applySavedEqualizerBands() {
+        val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
+        val minBandLevel = bandLevelRange[0].toInt() // 실제 Equalizer가 받을 수 있는 최소 밴드 레벨
+        val maxBandLevel = bandLevelRange[1].toInt() // 실제 Equalizer가 받을 수 있는 최대 밴드 레벨
+        val maxBandProgress = maxBandLevel - minBandLevel // SeekBar가 가질 수 있는 최대 progress
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
+
+        for (bandIndex in 0 until numberOfBands) {
+            val savedProgress = prefs.getInt(bandIndex.toString(), 0)
+            val clampedProgress = savedProgress.coerceIn(0, maxBandProgress)
+            val nativeLevel = (clampedProgress + minBandLevel).toShort()
+            val gainDb = mapEqProgressToDb(clampedProgress, maxBandProgress)
+
+            AudioEffectManager.applyEqualizerBandLevel(
+                bandIndex = bandIndex,
+                level = nativeLevel,
+            )
+            AudioEffectManager.setBandGain(bandIndex, gainDb)
+        }
+    }
+
+    private fun mapEqProgressToDb(progress: Int, max: Int): Float {
+        if (max <= 0) return 0.0f
+        val normalized = (progress.toFloat() / max.toFloat()).coerceIn(0.0f, 1.0f)
+
+        return (normalized * 24.0f) - 12.0f
+    }
+
+    // EQ 밴드 직접 조작만 Custom 전환 조건으로 사용한다.
+    override fun updateEqualizerBandFromUser(
+        bandIndex: Int,
+        progress: Int,
+    ) {
+        val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
+        val minBandLevel = bandLevelRange[0].toInt()
+        val maxBandLevel = bandLevelRange[1].toInt()
+        val maxBandProgress = maxBandLevel - minBandLevel
+
+        val clampedProgress = progress.coerceIn(0, maxBandProgress)
+
+        // SeekBar progress를 Android Equalizer가 요구하는 band level 값으로 변환한다.
+        val nativeBandLevel = (clampedProgress + minBandLevel).toShort()
+        val gainDb = mapEqProgressToDb(
+            progress = clampedProgress,
+            max = maxBandProgress,
+        )
+
+        prefs.edit {
+            putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
+            putInt(AudioSettingKeys.KEY_PRESET, AudioSettingsUiState.CUSTOM_PRESET_POSITION)
+            putInt(bandIndex.toString(), clampedProgress)
+        }
+
+        AudioEffectManager.applyEqualizerBandLevel(
+            bandIndex = bandIndex,
+            level = nativeBandLevel,
+        )
+        AudioEffectManager.setBandGain(bandIndex, gainDb)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
+    // BassBoost 값은 EQ 프리셋 선택 상태를 유지한 채 별도로 저장한다.
+    override fun updateBassStrength(progress: Int) {
+        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE)
+
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_BASS, clampedProgress)
+        }
+
+        AudioEffectManager.applyBassStrength(clampedProgress)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
+    // Virtualizer 값은 EQ 프리셋 선택 상태를 유지한 채 별도로 저장한다.
+    override fun updateVirtualizerStrength(progress: Int) {
+        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE)
+
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_VIRTUALIZER, clampedProgress)
+        }
+
+        AudioEffectManager.applyVirtualizerStrength(clampedProgress)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
+    override fun setLoudnessNormalizerEnabled(enabled: Boolean) {
+        prefs.edit {
+            putBoolean(AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED, enabled)
+        }
+
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+        updateStateFromStorage()
+    }
+
+    private fun updateStateFromStorage() {
+        _settingsState.value = loadAudioSettingsState()
+    }
+
+    // SharedPreferences에 저장된 값을 UI 상태 모델로 변환
+    private fun loadAudioSettingsState(): AudioSettingsUiState {
+        return AudioSettingsUiState(
+            isEqualizerEnabled = prefs.getBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, false),
+            currentPresetPosition = prefs.getInt(
+                AudioSettingKeys.KEY_PRESET,
+                AudioSettingsUiState.DEFAULT_PRESET_POSITION,
+            ),
+            bassStrength = prefs.getInt(
+                AudioSettingKeys.KEY_BASS,
+                AudioSettingsUiState.DEFAULT_EFFECT_VALUE,
+            ),
+            virtualizerStrength = prefs.getInt(
+                AudioSettingKeys.KEY_VIRTUALIZER,
+                AudioSettingsUiState.DEFAULT_EFFECT_VALUE,
+            ),
+            isLoudnessNormalizerEnabled = prefs.getBoolean(
+                AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED,
+                false,
+            ),
+        )
+    }
+
+    private companion object {
+        const val SETTINGS_PRESET_OFFSET = 1
+        const val MIN_EFFECT_VALUE = 0
+        const val MAX_EFFECT_VALUE = 100
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
@@ -9,4 +9,6 @@ object AudioSettingKeys {
     const val KEY_LOUDNESS_NORMALIZER_ENABLED = "LOUDNESS_NORMALIZER_ENABLED"
     const val KEY_SPATIAL_ENABLED = "SPATIAL_ENABLED"
     const val KEY_HEAD_TRACKING_ENABLED = "HEAD_TRACKING_ENABLED"
+
+    const val PREF_AUDIO_SETTINGS = "audio_settings"
 }

--- a/app/src/main/java/com/hero/ziggymusic/di/RepositoryModule.kt
+++ b/app/src/main/java/com/hero/ziggymusic/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
 package com.hero.ziggymusic.di
 
+import com.hero.ziggymusic.data.audio.repository.AudioSettingsRepositoryImpl
 import com.hero.ziggymusic.data.music.repository.MusicRepositoryImpl
+import com.hero.ziggymusic.domain.audio.repository.AudioSettingsRepository
 import com.hero.ziggymusic.domain.music.repository.MusicRepository
 import dagger.Binds
 import dagger.Module
@@ -16,4 +18,10 @@ abstract class RepositoryModule {
     abstract fun bindMusicRepository(
         musicRepositoryImpl: MusicRepositoryImpl
     ): MusicRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindAudioSettingsRepository(
+        audioSettingsRepositoryImpl: AudioSettingsRepositoryImpl,
+    ): AudioSettingsRepository
 }

--- a/app/src/main/java/com/hero/ziggymusic/domain/audio/repository/AudioSettingsRepository.kt
+++ b/app/src/main/java/com/hero/ziggymusic/domain/audio/repository/AudioSettingsRepository.kt
@@ -1,0 +1,32 @@
+package com.hero.ziggymusic.domain.audio.repository
+
+import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
+import kotlinx.coroutines.flow.StateFlow
+
+/*
+ * 음향 설정 저장소와 실제 오디오 효과 적용을 한 곳에서 관리한다.
+ */
+interface AudioSettingsRepository {
+    // AudioSettingsFragment와 AudioEffectBottomSheet가 같은 설정 상태를 관찰하기 위한 단일 상태 스트림
+    val settingsState: StateFlow<AudioSettingsUiState>
+
+    fun refreshSettings() // 저장된 값을 다시 읽어 현재 UI 상태로 반영한다.
+    fun applySavedSettings() // 앱 시작 또는 오디오 세션 생성 후 저장된 음향 설정을 실제 효과에 적용한다.
+
+    fun setEqualizerEnabled(enabled: Boolean)
+    fun setEqualizerPreset(presetPosition: Int) // 프리셋 선택 시 EQ를 켜고 현재 프리셋을 갱신한다.
+    fun setCustomEqualizerPreset() // 저장된 EQ 밴드 값을 사용하는 Custom 프리셋으로 전환한다.
+
+    // 사용자가 EQ 밴드를 직접 조정하면 Custom 프리셋으로 전환하고 값을 적용한다.
+    fun updateEqualizerBandFromUser(
+        bandIndex: Int,
+        progress: Int,
+    )
+
+    // BassBoost는 EQ 프리셋과 별도 효과이므로 currentPreset은 변경하지 않는다.
+    fun updateBassStrength(progress: Int)
+    // Virtualizer는 EQ 프리셋과 별도 효과이므로 currentPreset은 변경하지 않는다.
+    fun updateVirtualizerStrength(progress: Int)
+
+    fun setLoudnessNormalizerEnabled(enabled: Boolean)
+}

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -52,6 +52,7 @@ import com.hero.ziggymusic.presentation.main.player.manager.PlayerController
 import com.hero.ziggymusic.presentation.main.player.manager.PlayerMotionManager
 import com.hero.ziggymusic.presentation.main.player.viewmodel.PlayerViewModel
 import com.hero.ziggymusic.presentation.main.setting.AppSettingsFragment
+import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
@@ -60,6 +61,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
     private lateinit var binding: ActivityMainBinding
     private val vm by viewModels<MainViewModel>()
     private val playerVm by viewModels<PlayerViewModel>()
+    private val audioSettingsVm by viewModels<AudioSettingsViewModel>()
 
     @Inject
     lateinit var player: ExoPlayer
@@ -740,17 +742,15 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
 
     @OptIn(UnstableApi::class)
     private fun initSoundEQSettings() {
-        val prefs = getSharedPreferences(AudioSettingsFragment.TAG, MODE_PRIVATE)
-
         if (player.audioSessionId != 0) {
             AudioEffectManager.init(player.audioSessionId)
-            AudioEffectManager.setEnabledFromPrefs(prefs)
+            audioSettingsVm.applySavedSettings()
         } else {
             player.addListener(object : Player.Listener {
                 override fun onAudioSessionIdChanged(audioSessionId: Int) {
                     if (audioSessionId != 0) {
                         AudioEffectManager.init(audioSessionId)
-                        AudioEffectManager.setEnabledFromPrefs(prefs)
+                        audioSettingsVm.applySavedSettings()
                         player.removeListener(this)
                     }
                 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -85,11 +85,6 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         setupAudioSettingsState()
     }
 
-    private fun setupAudioSettingsState() {
-        observeAudioSettingsState()
-        vm.refreshSettings()
-    }
-
     private fun setupBottomSheetBehavior(dialog: BottomSheetDialog) {
         val bottomSheet = dialog.findViewById<View>(
             com.google.android.material.R.id.design_bottom_sheet,
@@ -101,23 +96,6 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
             state = BottomSheetBehavior.STATE_EXPANDED
             skipCollapsed = true
         }
-    }
-
-    private fun setupAudioEffectInitialState() {
-        binding.swLoudnessNormalizer.isChecked = prefs.getBoolean(
-            AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED,
-            false,
-        )
-
-        binding.seekBarBass.progress = prefs.getInt(
-            AudioSettingKeys.KEY_BASS,
-            DEFAULT_EFFECT_VALUE
-        )
-
-        binding.seekBarVirtualizer.progress = prefs.getInt(
-            AudioSettingKeys.KEY_VIRTUALIZER,
-            DEFAULT_EFFECT_VALUE,
-        )
     }
 
     // 바텀시트에서 프리셋을 누르면 EQ를 자동으로 켜고 프리셋을 적용한다.
@@ -171,6 +149,11 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         }
     }
 
+    private fun setupAudioSettingsState() {
+        observeAudioSettingsState()
+        vm.refreshSettings()
+    }
+
     // 바텀시트가 보이는 동안 ViewModel의 음향 설정 상태를 관찰한다.
     private fun observeAudioSettingsState() {
         viewLifecycleOwner.lifecycleScope.launch {
@@ -213,70 +196,6 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         }
 
         return recentPresetButtonIds.getOrNull(presetIndex)
-    }
-
-    private fun applyAudioEffectPreset(preset: AudioEffectPreset) {
-        if (preset == AudioEffectPreset.CUSTOM) {
-            saveCustomPresetSelection()
-            return
-        }
-
-        applyNativeEqualizerPresetIfAvailable(preset)
-        AudioEffectManager.setEnabledFromPrefs(prefs)
-    }
-
-    private fun applyNativeEqualizerPresetIfAvailable(preset: AudioEffectPreset) {
-        val nativePresetIndex = findNativeEqualizerPresetIndex(preset)
-
-        if (nativePresetIndex == null) {
-            saveCustomPresetSelection()
-            return
-        }
-
-        AudioEffectManager.useEqualizerPreset(nativePresetIndex)
-        prefs.edit {
-            putInt(AudioSettingKeys.KEY_PRESET, nativePresetIndex + SETTINGS_PRESET_OFFSET)
-        }
-    }
-
-    private fun findNativeEqualizerPresetIndex(preset: AudioEffectPreset): Int? {
-        val numberOfPresets = AudioEffectManager.getNumberOfPresets()
-        if (numberOfPresets <= 0) return null
-
-        val candidates = preset.config.equalizerPresetNameCandidates
-
-        return (0 until numberOfPresets).firstOrNull { index ->
-            val presetName = AudioEffectManager.getPresetName(index).orEmpty()
-            candidates.any { candidate ->
-                presetName.equals(candidate, ignoreCase = true)
-            }
-        }
-    }
-
-    private fun applyBass(progress: Int) {
-        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE) // 베이스 보정값
-
-        if (binding.seekBarBass.progress != clampedProgress) {
-            binding.seekBarBass.progress = clampedProgress
-        }
-
-        AudioEffectManager.applyBassStrength(clampedProgress, prefs)
-    }
-
-    private fun applyVirtualizer(progress: Int) {
-        val clampedProgress = progress.coerceIn(MIN_EFFECT_VALUE, MAX_EFFECT_VALUE) // 3D 버추얼라이저 보정값
-
-        if (binding.seekBarVirtualizer.progress != clampedProgress) {
-            binding.seekBarVirtualizer.progress = clampedProgress
-        }
-
-        AudioEffectManager.applyVirtualizerStrength(clampedProgress, prefs)
-    }
-
-    private fun saveCustomPresetSelection() {
-        prefs.edit {
-            putInt(AudioSettingKeys.KEY_PRESET, CUSTOM_PRESET_POSITION)
-        }
     }
 
     private fun createSeekBarChangeListener(

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -11,6 +11,10 @@ import android.view.ViewGroup
 import android.widget.SeekBar
 import androidx.core.content.edit
 import androidx.core.graphics.drawable.toDrawable
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -19,10 +23,18 @@ import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
 import com.hero.ziggymusic.databinding.FragmentAudioEffectBottomSheetBinding
 import com.hero.ziggymusic.playback.manager.AudioEffectManager
 import com.hero.ziggymusic.presentation.main.setting.AudioSettingsFragment
+import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
+import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
     private var _binding: FragmentAudioEffectBottomSheetBinding? = null
     private val binding get() = _binding!!
+
+    private val vm by activityViewModels<AudioSettingsViewModel>()
+    private var isApplyingAudioSettingsState = false // StateFlow 값을 UI에 반영하는 동안 리스너가 사용자 입력으로 오인하지 않도록 막는다.
 
     private lateinit var prefs: SharedPreferences
 
@@ -62,15 +74,20 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         prefs = requireContext().getSharedPreferences(
-            AudioSettingsFragment.TAG,
+            AudioSettingKeys.PREF_AUDIO_SETTINGS,
             Context.MODE_PRIVATE,
         )
 
-        setupAudioEffectInitialState()
         setupPresetControls()
         setupLoudnessNormalizer()
         setupAudioEffectSeekBars()
         setupSettingsNavigation()
+        setupAudioSettingsState()
+    }
+
+    private fun setupAudioSettingsState() {
+        observeAudioSettingsState()
+        vm.refreshSettings()
     }
 
     private fun setupBottomSheetBehavior(dialog: BottomSheetDialog) {
@@ -103,36 +120,41 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         )
     }
 
+    // 바텀시트에서 프리셋을 누르면 EQ를 자동으로 켜고 프리셋을 적용한다.
     private fun setupPresetControls() {
         binding.togglePresetGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
-            if (!isChecked) return@addOnButtonCheckedListener
+            if (!isChecked || isApplyingAudioSettingsState) return@addOnButtonCheckedListener
 
             val presetIndex = recentPresetButtonIds.indexOf(checkedId)
             val preset = recentPresets.getOrNull(presetIndex)
                 ?: return@addOnButtonCheckedListener
 
-            applyAudioEffectPreset(preset)
+            if (preset == AudioEffectPreset.CUSTOM) {
+                vm.setCustomEqualizerPreset()
+            } else {
+                vm.setEqualizerPreset(preset)
+            }
         }
     }
 
     private fun setupLoudnessNormalizer() {
         binding.swLoudnessNormalizer.setOnCheckedChangeListener { _, isChecked ->
-            AudioEffectManager.applyLoudnessNormalizer(isChecked, prefs)
+            if (isApplyingAudioSettingsState) return@setOnCheckedChangeListener
+            vm.setLoudnessNormalizerEnabled(isChecked)
         }
     }
 
+    // Bass/Virtualizer 조작은 프리셋 전환 없이 효과 값만 동기화한다.
     private fun setupAudioEffectSeekBars() {
         binding.seekBarBass.setOnSeekBarChangeListener(
             createSeekBarChangeListener { progress ->
-                applyBass(progress)
-                saveCustomPresetSelection()
+                vm.updateBassStrength(progress)
             },
         )
 
         binding.seekBarVirtualizer.setOnSeekBarChangeListener(
             createSeekBarChangeListener { progress ->
-                applyVirtualizer(progress)
-                saveCustomPresetSelection()
+                vm.updateVirtualizerStrength(progress)
             },
         )
     }
@@ -147,6 +169,50 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
             )
             dismiss()
         }
+    }
+
+    // 바텀시트가 보이는 동안 ViewModel의 음향 설정 상태를 관찰한다.
+    private fun observeAudioSettingsState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                vm.uiState.collect { state ->
+                    renderAudioSettingsState(state)
+                }
+            }
+        }
+    }
+
+    // 공유 상태를 바텀시트의 스위치, 프리셋, 슬라이더에 반영한다.
+    private fun renderAudioSettingsState(state: AudioSettingsUiState) {
+        isApplyingAudioSettingsState = true
+
+        if (binding.swLoudnessNormalizer.isChecked != state.isLoudnessNormalizerEnabled) {
+            binding.swLoudnessNormalizer.isChecked = state.isLoudnessNormalizerEnabled
+        }
+
+        if (binding.seekBarBass.progress != state.bassStrength) {
+            binding.seekBarBass.progress = state.bassStrength
+        }
+
+        if (binding.seekBarVirtualizer.progress != state.virtualizerStrength) {
+            binding.seekBarVirtualizer.progress = state.virtualizerStrength
+        }
+
+        val checkedButtonId = findPresetButtonId(state.currentPresetPosition)
+        if (checkedButtonId != null && binding.togglePresetGroup.checkedButtonId != checkedButtonId) {
+            binding.togglePresetGroup.check(checkedButtonId)
+        }
+
+        isApplyingAudioSettingsState = false
+    }
+
+    // 현재 프리셋 position에 대응하는 바텀시트 버튼 id를 찾는다.
+    private fun findPresetButtonId(presetPosition: Int): Int? {
+        val presetIndex = recentPresets.indexOfFirst {
+            it.config.settingsPresetPosition == presetPosition
+        }
+
+        return recentPresetButtonIds.getOrNull(presetIndex)
     }
 
     private fun applyAudioEffectPreset(preset: AudioEffectPreset) {
@@ -222,13 +288,12 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
                 progress: Int,
                 fromUser: Boolean,
             ) {
-                if (fromUser) {
+                if (fromUser && !isApplyingAudioSettingsState) {
                     onProgressChangedByUser(progress)
                 }
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
-
             override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
         }
     }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -20,19 +20,30 @@ import androidx.fragment.app.Fragment
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.databinding.FragmentAudioSettingsBinding
 import androidx.core.content.edit
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
 import com.hero.ziggymusic.playback.audio.HeadTracker
 import com.hero.ziggymusic.playback.audio.PlayerAudioGraph
 import com.hero.ziggymusic.playback.audio.SpatializerSupport
 import com.hero.ziggymusic.playback.manager.AudioEffectManager
-import com.hero.ziggymusic.playback.manager.AudioEffectManager.equalizer
 import com.hero.ziggymusic.playback.manager.AudioEffectManager.mainColor
+import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
+import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import com.hero.ziggymusic.presentation.main.setting.widget.SoundEQVerticalSeekbar
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.util.Locale
 
+@AndroidEntryPoint
 class AudioSettingsFragment : Fragment() {
     private var _binding: FragmentAudioSettingsBinding? = null
     private val binding get() = _binding!!
+
+    private val vm by activityViewModels<AudioSettingsViewModel>()
+    private var isApplyingAudioSettingsState = false
 
     var seekbarIds: ArrayList<Int> = ArrayList()
 
@@ -70,6 +81,8 @@ class AudioSettingsFragment : Fragment() {
         initLoudnessNormalizer()
         initVirtualizerSeekbar()
         initSpatialAudioUi() // XR 기능 UI 설정
+        observeAudioSettingsState()
+        vm.refreshSettings()
     }
 
     // Spatial Audio & Head Tracking UI 설정
@@ -178,16 +191,54 @@ class AudioSettingsFragment : Fragment() {
     }
 
     private fun initSetting() {
-        prefs = requireContext().getSharedPreferences(TAG, 0)
+        prefs = requireContext().getSharedPreferences(AudioSettingKeys.PREF_AUDIO_SETTINGS, 0)
         AudioEffectManager.setEnabledFromPrefs(prefs)
 
-        val isEqualizerEnabled = prefs.getBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, false)
-        binding.swEqualizer.isChecked = isEqualizerEnabled
+        // 사용자가 직접 EQ 스위치를 바꾼 경우에만 상태를 갱신한다.
         binding.swEqualizer.setOnCheckedChangeListener { _, isChecked ->
-            prefs.edit { putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, isChecked) }
-            AudioEffectManager.setEnabledFromPrefs(prefs)
-            updateEqualizerUiState(isChecked)
+            if (isApplyingAudioSettingsState) return@setOnCheckedChangeListener
+            vm.setEqualizerEnabled(isChecked)
         }
+    }
+
+    private fun observeAudioSettingsState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                vm.uiState.collect { state ->
+                    renderAudioSettingsState(state)
+                }
+            }
+        }
+    }
+
+    private fun renderAudioSettingsState(state: AudioSettingsUiState) {
+        isApplyingAudioSettingsState = true
+
+        if (binding.swEqualizer.isChecked != state.isEqualizerEnabled) {
+            binding.swEqualizer.isChecked = state.isEqualizerEnabled
+        }
+
+        updateEqualizerUiState(state.isEqualizerEnabled)
+
+        if (binding.spinnerPreset.adapter != null &&
+            binding.spinnerPreset.selectedItemPosition != state.currentPresetPosition
+        ) {
+            binding.spinnerPreset.setSelection(state.currentPresetPosition)
+        }
+
+        if (binding.swLoudnessNormalizer.isChecked != state.isLoudnessNormalizerEnabled) {
+            binding.swLoudnessNormalizer.isChecked = state.isLoudnessNormalizerEnabled
+        }
+
+        if (binding.sbBass.progress != state.bassStrength) {
+            binding.sbBass.progress = state.bassStrength
+        }
+
+        if (binding.sbVirtualizer.progress != state.virtualizerStrength) {
+            binding.sbVirtualizer.progress = state.virtualizerStrength
+        }
+
+        isApplyingAudioSettingsState = false
     }
 
     private fun initPresets(min: Int) {
@@ -210,6 +261,7 @@ class AudioSettingsFragment : Fragment() {
         binding.spinnerPreset.adapter = spinnerAdapter
         binding.spinnerPreset.setSelection(prefs.getInt(AudioSettingKeys.KEY_PRESET, 1))
 
+        // 프리셋 선택은 EQ 프리셋 상태만 바꾸고 Bass/Virtualizer 값은 유지한다.
         binding.spinnerPreset.onItemSelectedListener =
             object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(
@@ -218,21 +270,12 @@ class AudioSettingsFragment : Fragment() {
                     position: Int,
                     id: Long,
                 ) {
-                    if (equalizer != null) {
-                        prefs.edit { putInt(AudioSettingKeys.KEY_PRESET, position) }
+                    if (isApplyingAudioSettingsState) return
 
-                        if (position != 0) {
-                            AudioEffectManager.useEqualizerPreset(position - 1)
-
-                            for (i in seekbarIds.indices) {
-                                val seekbar =
-                                    requireActivity().findViewById<SoundEQVerticalSeekbar>(seekbarIds[i])
-                                seekbar.progress = 1
-                                seekbar.progress =
-                                    (AudioEffectManager.getBandLevel(i)?.toInt() ?: 0) - min
-                                seekbar.refreshThumbState()
-                            }
-                        }
+                    if (position == AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+                        vm.setCustomEqualizerPreset()
+                    } else {
+                        vm.setEqualizerPreset(position)
                     }
                 }
 
@@ -274,31 +317,20 @@ class AudioSettingsFragment : Fragment() {
                 (AudioEffectManager.getBandLevel(index)?.toInt() ?: 0) - min
             )
 
-            verticalSeekbar.setOnSeekBarChangeListener(object :
-                SeekBar.OnSeekBarChangeListener { override fun onProgressChanged(
-                seekBar: SeekBar,
-                progress: Int,
-                fromUser: Boolean,
-            ) {
-                if (!verticalSeekbar.isTrackingTouch) return
+            verticalSeekbar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(
+                    seekBar: SeekBar,
+                    progress: Int,
+                    fromUser: Boolean,
+                ) {
+                    if (!fromUser || isApplyingAudioSettingsState) return
 
-                binding.spinnerPreset.setSelection(0)
-                prefs.edit { putInt(seekBar.tag.toString(), progress) }
-
-                if (equalizer?.enabled == true) {
-                    AudioEffectManager.applyEqualizerBandLevel(
+                    // EQ 밴드 직접 조작은 Custom 프리셋 전환 조건이다.
+                    vm.updateEqualizerBandFromUser(
                         bandIndex = seekBar.tag as Int,
-                        level = (progress + min).toShort()
+                        progress = progress
                     )
                 }
-
-                val bandIndex = seekBar.tag as Int
-                val gainDb = mapEqProgressToDb(
-                    progress = progress,
-                    max = seekBar.max
-                )
-                AudioEffectManager.setBandGain(bandIndex, gainDb)
-            }
 
                 override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
                 override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
@@ -433,12 +465,9 @@ class AudioSettingsFragment : Fragment() {
     }
 
     private fun initLoudnessNormalizer() {
-        val loudnessEnabled = prefs.getBoolean(AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED, false)
-
-        binding.swLoudnessNormalizer.setOnCheckedChangeListener(null)
-        binding.swLoudnessNormalizer.isChecked = loudnessEnabled
         binding.swLoudnessNormalizer.setOnCheckedChangeListener { _, isChecked ->
-            AudioEffectManager.applyLoudnessNormalizer(isChecked, prefs)
+            if (isApplyingAudioSettingsState) return@setOnCheckedChangeListener
+            vm.setLoudnessNormalizerEnabled(isChecked)
         }
     }
 
@@ -451,9 +480,11 @@ class AudioSettingsFragment : Fragment() {
         binding.sbBass.thumb.setTint(mainColor)
         binding.sbBass.progress = bassProgress
 
+        // BassBoost는 EQ 프리셋과 독립된 효과이므로 프리셋 상태를 바꾸지 않는다.
         binding.sbBass.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                AudioEffectManager.applyBassStrength(progress, prefs)
+                if (!fromUser || isApplyingAudioSettingsState) return
+                vm.updateBassStrength(progress)
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
@@ -470,9 +501,11 @@ class AudioSettingsFragment : Fragment() {
         binding.sbVirtualizer.thumb.setTint(mainColor)
         binding.sbVirtualizer.progress = virtualizerProgress
 
+        // Virtualizer는 EQ 프리셋과 독립된 효과이므로 프리셋 상태를 바꾸지 않는다.
         binding.sbVirtualizer.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                AudioEffectManager.applyVirtualizerStrength(progress, prefs)
+                if (!fromUser || isApplyingAudioSettingsState) return
+                vm.updateVirtualizerStrength(progress)
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
@@ -1,0 +1,21 @@
+package com.hero.ziggymusic.presentation.main.setting.model
+
+/**
+ * 설정 화면과 바텀시트가 함께 관찰하는 음향 설정 UI 상태.
+ *
+ * Custom 프리셋은 EQ 밴드 직접 조작 상태를 의미하며,
+ * BassBoost/Virtualizer 값은 EQ 프리셋과 독립적으로 관리한다.
+ */
+data class AudioSettingsUiState(
+    val isEqualizerEnabled: Boolean = false,
+    val currentPresetPosition: Int = DEFAULT_PRESET_POSITION,
+    val bassStrength: Int = DEFAULT_EFFECT_VALUE,
+    val virtualizerStrength: Int = DEFAULT_EFFECT_VALUE,
+    val isLoudnessNormalizerEnabled: Boolean = false,
+) {
+    companion object {
+        const val CUSTOM_PRESET_POSITION = 0 // 0번은 사용자가 EQ 밴드를 직접 조정한 Custom 프리셋 위치를 의미한다.
+        const val DEFAULT_PRESET_POSITION = 1 // 기본 프리셋은 설정 화면의 spinner 기준 1번 항목으로 시작한다.
+        const val DEFAULT_EFFECT_VALUE = 0
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/viewmodel/AudioSettingsViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/viewmodel/AudioSettingsViewModel.kt
@@ -1,0 +1,62 @@
+package com.hero.ziggymusic.presentation.main.setting.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.hero.ziggymusic.domain.audio.repository.AudioSettingsRepository
+import com.hero.ziggymusic.presentation.main.player.audioeffect.AudioEffectPreset
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AudioSettingsViewModel @Inject constructor(
+    private val audioSettingsRepository: AudioSettingsRepository,
+) : ViewModel() {
+    val uiState = audioSettingsRepository.settingsState
+
+    fun refreshSettings() {
+        audioSettingsRepository.refreshSettings()
+    }
+
+    fun applySavedSettings() {
+        audioSettingsRepository.applySavedSettings()
+    }
+
+    fun setEqualizerEnabled(enabled: Boolean) {
+        audioSettingsRepository.setEqualizerEnabled(enabled)
+    }
+
+    // 설정 화면 spinner에서 선택한 프리셋 position을 그대로 Repository에 전달한다.
+    fun setEqualizerPreset(presetPosition: Int) {
+        audioSettingsRepository.setEqualizerPreset(presetPosition)
+    }
+
+    // 바텀시트 프리셋 모델을 설정 화면 spinner position으로 변환해 적용한다.
+    fun setEqualizerPreset(preset: AudioEffectPreset) {
+        audioSettingsRepository.setEqualizerPreset(preset.config.settingsPresetPosition)
+    }
+
+    fun setCustomEqualizerPreset() {
+        audioSettingsRepository.setCustomEqualizerPreset()
+    }
+
+    fun updateEqualizerBandFromUser(
+        bandIndex: Int,
+        progress: Int,
+    ) {
+        audioSettingsRepository.updateEqualizerBandFromUser(
+            bandIndex = bandIndex,
+            progress = progress,
+        )
+    }
+
+    fun updateBassStrength(progress: Int) {
+        audioSettingsRepository.updateBassStrength(progress)
+    }
+
+    fun updateVirtualizerStrength(progress: Int) {
+        audioSettingsRepository.updateVirtualizerStrength(progress)
+    }
+
+    fun setLoudnessNormalizerEnabled(enabled: Boolean) {
+        audioSettingsRepository.setLoudnessNormalizerEnabled(enabled)
+    }
+}


### PR DESCRIPTION
# PR 내용
1. `AudioSettingsViewModel`/`AudioSettingsRepository` 기반 상태 동기화 추가
- `AudioSettingsFragment`와 `AudioEffectBottomSheetDialogFragment`가 같은 StateFlow를 관찰하도록 구조 개선
- EQ On/Off, 현재 프리셋, 베이스, 3D 버추얼라이저, 음량 평준화 상태를 단일 경로로 관리
- `SharedPreferences` 접근과 `AudioEffectManager` 적용 로직을 `AudioSettingsRepository`로 집중

2. EQ 프리셋 및 Custom 동작 정리
- 바텀시트에서 프리셋 선택 시 EQ를 자동으로 켜고 선택 프리셋을 적용
- EQ 밴드 5개를 사용자가 직접 조작한 경우에만 Custom 프리셋으로 전환
- 베이스, 3D 버추얼라이저 조작은 EQ 프리셋 상태를 변경하지 않고 효과 값만 동기화

3. 저장된 음향 설정 복원 처리 개선
- 앱 시작 또는 오디오 세션 생성 시 저장된 음향 설정을 동일한 ViewModel 경로로 적용
- Custom 프리셋 상태에서는 저장된 EQ 밴드 값을 복원
- 저장된 EQ 밴드 progress를 안전한 범위로 보정해 적용

4. 바텀시트 음향 설정 코드 정리
- 기존 `SharedPreferences` 직접 접근 흐름을 ViewModel 기반 흐름으로 대체
- 사용되지 않는 이전 방식의 프리셋/베이스/3D 버추얼라이저 적용 메서드 정리
- 상태 반영 중 발생하는 UI 콜백이 사용자 입력으로 처리되지 않도록 방지