### PR TITLE
[ Refactor ] AudioSettingsFragment 음향 설정 상태 처리 정리

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
@@ -34,7 +34,6 @@ class AudioSettingsRepositoryImpl @Inject constructor(
     override fun applySavedSettings() {
         val savedAudioSettings = loadAudioSettingsState()
 
-        // 저장된 프리셋이 Custom이 아니면 Android Equalizer 프리셋을 먼저 적용한다.
         if (savedAudioSettings.currentPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
             AudioEffectManager.useEqualizerPreset(
                 savedAudioSettings.currentPresetPosition - SETTINGS_PRESET_OFFSET
@@ -43,8 +42,10 @@ class AudioSettingsRepositoryImpl @Inject constructor(
             applySavedEqualizerBands()
         }
 
+        // 저장된 별도 음향 효과 값도 프리셋과 함께 복원한다.
         AudioEffectManager.applyBassStrength(savedAudioSettings.bassStrength)
         AudioEffectManager.applyVirtualizerStrength(savedAudioSettings.virtualizerStrength)
+        AudioEffectManager.applyReverbPreset(savedAudioSettings.reverbPresetPosition)
         AudioEffectManager.setEnabledFromPrefs(prefs)
 
         updateStateFromStorage()
@@ -185,6 +186,20 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         updateStateFromStorage()
     }
 
+    // Reverb 값은 EQ 프리셋 선택 상태를 유지한 채 별도로 저장한다.
+    override fun setReverbPreset(position: Int) {
+        val normalizedPosition = position.coerceIn(MIN_REVERB_PRESET_POSITION, MAX_REVERB_PRESET_POSITION)
+
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_REVERB, normalizedPosition)
+        }
+
+        AudioEffectManager.applyReverbPreset(normalizedPosition)
+        AudioEffectManager.setEnabledFromPrefs(prefs)
+
+        updateStateFromStorage()
+    }
+
     override fun setLoudnessNormalizerEnabled(enabled: Boolean) {
         prefs.edit {
             putBoolean(AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED, enabled)
@@ -214,6 +229,10 @@ class AudioSettingsRepositoryImpl @Inject constructor(
                 AudioSettingKeys.KEY_VIRTUALIZER,
                 AudioSettingsUiState.DEFAULT_EFFECT_VALUE,
             ),
+            reverbPresetPosition = prefs.getInt(
+                AudioSettingKeys.KEY_REVERB,
+                AudioSettingsUiState.DEFAULT_REVERB_PRESET_POSITION,
+            ),
             isLoudnessNormalizerEnabled = prefs.getBoolean(
                 AudioSettingKeys.KEY_LOUDNESS_NORMALIZER_ENABLED,
                 false,
@@ -225,5 +244,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         const val SETTINGS_PRESET_OFFSET = 1
         const val MIN_EFFECT_VALUE = 0
         const val MAX_EFFECT_VALUE = 100
+        const val MIN_REVERB_PRESET_POSITION = 0
+        const val MAX_REVERB_PRESET_POSITION = 6
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/domain/audio/repository/AudioSettingsRepository.kt
+++ b/app/src/main/java/com/hero/ziggymusic/domain/audio/repository/AudioSettingsRepository.kt
@@ -25,8 +25,12 @@ interface AudioSettingsRepository {
 
     // BassBoost는 EQ 프리셋과 별도 효과이므로 currentPreset은 변경하지 않는다.
     fun updateBassStrength(progress: Int)
+
     // Virtualizer는 EQ 프리셋과 별도 효과이므로 currentPreset은 변경하지 않는다.
     fun updateVirtualizerStrength(progress: Int)
+
+    // Reverb는 EQ 프리셋과 별도 효과이므로 currentPreset은 변경하지 않는다.
+    fun setReverbPreset(position: Int)
 
     fun setLoudnessNormalizerEnabled(enabled: Boolean)
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -45,11 +45,11 @@ class AudioSettingsFragment : Fragment() {
     private val vm by activityViewModels<AudioSettingsViewModel>()
     private var isApplyingAudioSettingsState = false
 
-    // Spinner adapter 연결 직후 발생하는 초기 선택 콜백을 사용자 선택과 구분하기 위한 플래그.
+    // Spinner adapter 연결 직후 발생하는 초기 선택 콜백을 사용자 선택과 구분하기 위한 플래그
     private var isPresetSpinnerReady = false
     private var isReverbSpinnerReady = false
 
-    var seekbarIds: ArrayList<Int> = ArrayList()
+    private val equalizerBandSeekBarIds = mutableListOf<Int>()
 
     private lateinit var prefs: SharedPreferences
 
@@ -303,39 +303,41 @@ class AudioSettingsFragment : Fragment() {
 
     private fun initEqualizer() {
         val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
-        val max = bandLevelRange[1].toInt()
-        val min = bandLevelRange[0].toInt()
+        val minBandLevel = bandLevelRange[0].toInt()
+        val maxBandLevel = bandLevelRange[1].toInt()
         var uiMaxForNative = 0
 
-        seekbarIds.clear()
+        equalizerBandSeekBarIds.clear()
         binding.tvSeekbar.removeAllViews()
         binding.seekbarContainer.removeAllViews()
 
         val numberOfBands = AudioEffectManager.getNumberOfBands()
 
         for (index in 0 until numberOfBands) {
-            val verticalSeekbar = SoundEQVerticalSeekbar(requireContext())
-            seekbarIds.add(index, View.generateViewId())
-            verticalSeekbar.max = max - min
-            verticalSeekbar.tag = index
-            uiMaxForNative = verticalSeekbar.max
+            val equalizerBandSeekBar = SoundEQVerticalSeekbar(requireContext())
+
+            equalizerBandSeekBarIds.add(index, View.generateViewId())
+
+            equalizerBandSeekBar.max = maxBandLevel - minBandLevel
+            equalizerBandSeekBar.tag = index
+            uiMaxForNative = equalizerBandSeekBar.max
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                verticalSeekbar.maxHeight = 1
+                equalizerBandSeekBar.maxHeight = 1
             }
 
-            verticalSeekbar.id = seekbarIds[index]
-            verticalSeekbar.splitTrack = true
+            equalizerBandSeekBar.id = equalizerBandSeekBarIds[index]
+            equalizerBandSeekBar.splitTrack = true
 
-            verticalSeekbar.progressDrawable.setTint(mainColor)
-            verticalSeekbar.thumb.setTint(mainColor)
+            equalizerBandSeekBar.progressDrawable.setTint(mainColor)
+            equalizerBandSeekBar.thumb.setTint(mainColor)
 
-            verticalSeekbar.progress = prefs.getInt(
+            equalizerBandSeekBar.progress = prefs.getInt(
                 index.toString(),
-                (AudioEffectManager.getBandLevel(index)?.toInt() ?: 0) - min
+                (AudioEffectManager.getBandLevel(index)?.toInt() ?: 0) - minBandLevel
             )
 
-            verticalSeekbar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            equalizerBandSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
                 override fun onProgressChanged(
                     seekBar: SeekBar,
                     progress: Int,
@@ -354,36 +356,37 @@ class AudioSettingsFragment : Fragment() {
                 override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
             })
 
-            val seekbarLayoutParams =
+            val equalizerBandSeekBarLayoutParams =
                 LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1.0f)
-            verticalSeekbar.layoutParams = seekbarLayoutParams
+            equalizerBandSeekBar.layoutParams = equalizerBandSeekBarLayoutParams
 
             val centerFreq = AudioEffectManager.getCenterFreq(index) ?: 0
-            val title = formatCenterFreq(centerFreq)
+            val frequencyLabel = formatCenterFreq(centerFreq)
 
-            val textView = TextView(requireContext())
-            textView.text = title
-            textView.includeFontPadding = false
-            textView.maxLines = 1
-            textView.setTextSize(
+            val frequencyLabelView = TextView(requireContext())
+            frequencyLabelView.text = frequencyLabel
+            frequencyLabelView.includeFontPadding = false
+            frequencyLabelView.maxLines = 1
+            frequencyLabelView.setTextSize(
                 TypedValue.COMPLEX_UNIT_PX,
                 resources.getDimension(R.dimen.setting_eq_label_text_size)
             )
-            textView.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
+            frequencyLabelView.setTextColor(ContextCompat.getColor(requireContext(), R.color.white))
 
-            val params =
+            val frequencyLabelLayoutParams =
                 LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
-            textView.gravity = Gravity.CENTER
-            textView.layoutParams = params
+            frequencyLabelView.gravity = Gravity.CENTER
+            frequencyLabelView.layoutParams = frequencyLabelLayoutParams
 
-            binding.tvSeekbar.addView(textView)
-            binding.seekbarContainer.addView(verticalSeekbar)
-            verticalSeekbar.post { verticalSeekbar.refreshThumbState() }
+            binding.tvSeekbar.addView(frequencyLabelView)
+            binding.seekbarContainer.addView(equalizerBandSeekBar)
+            equalizerBandSeekBar.post { equalizerBandSeekBar.refreshThumbState() }
 
             val initialGainDb = mapEqProgressToDb(
-                progress = verticalSeekbar.progress,
-                max = verticalSeekbar.max
+                progress = equalizerBandSeekBar.progress,
+                max = equalizerBandSeekBar.max
             )
+
             AudioEffectManager.setBandGain(index, initialGainDb)
         }
 
@@ -413,14 +416,14 @@ class AudioSettingsFragment : Fragment() {
         binding.tvSeekbar.alpha = contentAlpha
 
         for (index in 0 until binding.seekbarContainer.childCount) {
-            val seekbar = binding.seekbarContainer.getChildAt(index) as? SoundEQVerticalSeekbar
+            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? SoundEQVerticalSeekbar
                 ?: continue
 
-            seekbar.isEnabled = isEnabled
-            seekbar.progressDrawable.mutate().setTint(seekbarTint)
-            seekbar.thumb.mutate().setTint(seekbarTint)
-            seekbar.setTickAlpha(tickAlpha)
-            seekbar.refreshThumbState()
+            equalizerBandSeekBar.isEnabled = isEnabled
+            equalizerBandSeekBar.progressDrawable.mutate().setTint(seekbarTint)
+            equalizerBandSeekBar.thumb.mutate().setTint(seekbarTint)
+            equalizerBandSeekBar.setTickAlpha(tickAlpha)
+            equalizerBandSeekBar.refreshThumbState()
         }
 
         for (index in 0 until binding.tvSeekbar.childCount) {
@@ -545,13 +548,13 @@ class AudioSettingsFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(): AudioSettingsFragment = AudioSettingsFragment()
-
         const val TAG = "AudioSettingsFragment"
 
         private const val EQ_ENABLED_ALPHA = 1.0f
         private const val EQ_DISABLED_CONTENT_ALPHA = 0.55f
         private const val EQ_DISABLED_SCALE_ALPHA = 0.5f
         private const val EQ_DISABLED_TICK_ALPHA = 0.45f
+
+        fun newInstance(): AudioSettingsFragment = AudioSettingsFragment()
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -45,6 +45,10 @@ class AudioSettingsFragment : Fragment() {
     private val vm by activityViewModels<AudioSettingsViewModel>()
     private var isApplyingAudioSettingsState = false
 
+    // Spinner adapter 연결 직후 발생하는 초기 선택 콜백을 사용자 선택과 구분하기 위한 플래그.
+    private var isPresetSpinnerReady = false
+    private var isReverbSpinnerReady = false
+
     var seekbarIds: ArrayList<Int> = ArrayList()
 
     private lateinit var prefs: SharedPreferences
@@ -226,6 +230,13 @@ class AudioSettingsFragment : Fragment() {
             binding.spinnerPreset.setSelection(state.currentPresetPosition)
         }
 
+        // Reverb 선택 위치도 공유 상태를 기준으로 맞춘다.
+        if (binding.spinnerReverb.adapter != null &&
+            binding.spinnerReverb.selectedItemPosition != state.reverbPresetPosition
+        ) {
+            binding.spinnerReverb.setSelection(state.reverbPresetPosition)
+        }
+
         if (binding.swLoudnessNormalizer.isChecked != state.isLoudnessNormalizerEnabled) {
             binding.swLoudnessNormalizer.isChecked = state.isLoudnessNormalizerEnabled
         }
@@ -241,9 +252,11 @@ class AudioSettingsFragment : Fragment() {
         isApplyingAudioSettingsState = false
     }
 
-    private fun initPresets(min: Int) {
+    private fun initPresets() {
         val noOfPresets = AudioEffectManager.getNumberOfPresets()
         if (noOfPresets <= 0) return
+
+        isPresetSpinnerReady = false
 
         val presets = arrayOfNulls<String>(noOfPresets + 1)
         presets[0] = "Custom"
@@ -259,7 +272,11 @@ class AudioSettingsFragment : Fragment() {
         )
 
         binding.spinnerPreset.adapter = spinnerAdapter
-        binding.spinnerPreset.setSelection(prefs.getInt(AudioSettingKeys.KEY_PRESET, 1))
+
+        // Adapter 연결 직후 발생할 수 있는 초기 onItemSelected 콜백은 무시한다.
+        binding.spinnerPreset.post {
+            isPresetSpinnerReady = true
+        }
 
         // 프리셋 선택은 EQ 프리셋 상태만 바꾸고 Bass/Virtualizer 값은 유지한다.
         binding.spinnerPreset.onItemSelectedListener =
@@ -270,7 +287,8 @@ class AudioSettingsFragment : Fragment() {
                     position: Int,
                     id: Long,
                 ) {
-                    if (isApplyingAudioSettingsState) return
+                    // 초기화 중 발생한 선택 콜백은 사용자 입력이 아니므로 처리하지 않는다.
+                    if (!isPresetSpinnerReady || isApplyingAudioSettingsState) return
 
                     if (position == AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
                         vm.setCustomEqualizerPreset()
@@ -373,7 +391,7 @@ class AudioSettingsFragment : Fragment() {
             AudioEffectManager.applySettingsFromPrefs(prefs, eqMaxFromUi = uiMaxForNative)
         }
 
-        initPresets(min)
+        initPresets()
         updateEqualizerUiState(binding.swEqualizer.isChecked)
     }
 
@@ -432,6 +450,8 @@ class AudioSettingsFragment : Fragment() {
     }
 
     private fun initReverb() {
+        isReverbSpinnerReady = false
+
         val reverbAdapter = ArrayAdapter(
             requireContext(),
             R.layout.item_spinner,
@@ -443,10 +463,15 @@ class AudioSettingsFragment : Fragment() {
                 "Medium Hall",
                 "Large Hall",
                 "Plate"
-            ))
+            )
+        )
 
         binding.spinnerReverb.adapter = reverbAdapter
-        binding.spinnerReverb.setSelection(prefs.getInt(AudioSettingKeys.KEY_REVERB, 0))
+
+        // Adapter 연결 직후 발생할 수 있는 초기 onItemSelected 콜백은 무시한다.
+        binding.spinnerReverb.post {
+            isReverbSpinnerReady = true
+        }
 
         binding.spinnerReverb.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
@@ -455,9 +480,10 @@ class AudioSettingsFragment : Fragment() {
                 position: Int,
                 id: Long,
             ) {
-                if (AudioEffectManager.reverb != null) {
-                    AudioEffectManager.applyReverbPreset(position, prefs)
-                }
+                // 초기화 중 발생한 선택 콜백은 사용자 입력이 아니므로 처리하지 않는다.
+                if (!isReverbSpinnerReady || isApplyingAudioSettingsState) return
+
+                vm.setReverbPreset(position)
             }
 
             override fun onNothingSelected(parent: AdapterView<*>?) = Unit
@@ -472,13 +498,8 @@ class AudioSettingsFragment : Fragment() {
     }
 
     private fun initBassSeekBar(settings: SharedPreferences) {
-        val bassProgress = settings.getInt(AudioSettingKeys.KEY_BASS, 0)
-
-        AudioEffectManager.applyBassStrength(bassProgress)
-
         binding.sbBass.progressDrawable.setTint(mainColor)
         binding.sbBass.thumb.setTint(mainColor)
-        binding.sbBass.progress = bassProgress
 
         // BassBoost는 EQ 프리셋과 독립된 효과이므로 프리셋 상태를 바꾸지 않는다.
         binding.sbBass.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
@@ -493,15 +514,10 @@ class AudioSettingsFragment : Fragment() {
     }
 
     private fun initVirtualizerSeekbar() {
-        val virtualizerProgress = prefs.getInt(AudioSettingKeys.KEY_VIRTUALIZER, 0)
-
-        AudioEffectManager.applyVirtualizerStrength(virtualizerProgress)
-
         binding.sbVirtualizer.progressDrawable.setTint(mainColor)
         binding.sbVirtualizer.thumb.setTint(mainColor)
-        binding.sbVirtualizer.progress = virtualizerProgress
 
-        // Virtualizer는 EQ 프리셋과 독립된 효과이므로 프리셋 상태를 바꾸지 않는다.
+        // 3D Virtualizer는 EQ 프리셋과 독립된 효과이므로 프리셋 상태를 바꾸지 않는다.
         binding.sbVirtualizer.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 if (!fromUser || isApplyingAudioSettingsState) return
@@ -516,22 +532,9 @@ class AudioSettingsFragment : Fragment() {
     override fun onResume() {
         super.onResume()
 
-        binding.sbVirtualizer.progress = prefs.getInt(AudioSettingKeys.KEY_VIRTUALIZER, 0)
-        binding.sbBass.progress = prefs.getInt(AudioSettingKeys.KEY_BASS, 0)
-
-        // 화면에 돌아왔을 때 설정에 따라 트래킹 재개
+        // 화면에 돌아왔을 때 Head Tracking이 켜져 있으면 센서 추적을 재개한다.
         if (binding.swSpatialAudio.isChecked && binding.swHeadTracking.isChecked) {
             headTracker.start()
-        }
-    }
-
-    override fun onPause() {
-        super.onPause()
-
-        // Preference 저장 로직
-        prefs.edit {
-            putInt(AudioSettingKeys.KEY_BASS, binding.sbBass.progress)
-            putInt(AudioSettingKeys.KEY_VIRTUALIZER, binding.sbVirtualizer.progress)
         }
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
@@ -4,18 +4,26 @@ package com.hero.ziggymusic.presentation.main.setting.model
  * 설정 화면과 바텀시트가 함께 관찰하는 음향 설정 UI 상태.
  *
  * Custom 프리셋은 EQ 밴드 직접 조작 상태를 의미하며,
- * BassBoost/Virtualizer 값은 EQ 프리셋과 독립적으로 관리한다.
+ * Bass/Virtualizer/Reverb 값은 EQ 프리셋과 독립적으로 관리한다.
  */
 data class AudioSettingsUiState(
     val isEqualizerEnabled: Boolean = false,
     val currentPresetPosition: Int = DEFAULT_PRESET_POSITION,
     val bassStrength: Int = DEFAULT_EFFECT_VALUE,
     val virtualizerStrength: Int = DEFAULT_EFFECT_VALUE,
+    val reverbPresetPosition: Int = DEFAULT_REVERB_PRESET_POSITION,
     val isLoudnessNormalizerEnabled: Boolean = false,
 ) {
     companion object {
-        const val CUSTOM_PRESET_POSITION = 0 // 0번은 사용자가 EQ 밴드를 직접 조정한 Custom 프리셋 위치를 의미한다.
-        const val DEFAULT_PRESET_POSITION = 1 // 기본 프리셋은 설정 화면의 spinner 기준 1번 항목으로 시작한다.
+        // 사용자가 EQ 밴드를 직접 조정한 Custom 프리셋 위치
+        const val CUSTOM_PRESET_POSITION = 0
+
+        // 설정 화면 spinner 기준 기본 EQ 프리셋 위치
+        const val DEFAULT_PRESET_POSITION = 1
+
+        // 설정 화면 spinner 기준 리버브 프리셋 위치
+        const val DEFAULT_REVERB_PRESET_POSITION = 0
+
         const val DEFAULT_EFFECT_VALUE = 0
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/viewmodel/AudioSettingsViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/viewmodel/AudioSettingsViewModel.kt
@@ -56,6 +56,10 @@ class AudioSettingsViewModel @Inject constructor(
         audioSettingsRepository.updateVirtualizerStrength(progress)
     }
 
+    fun setReverbPreset(position: Int) {
+        audioSettingsRepository.setReverbPreset(position)
+    }
+
     fun setLoudnessNormalizerEnabled(enabled: Boolean) {
         audioSettingsRepository.setLoudnessNormalizerEnabled(enabled)
     }


### PR DESCRIPTION
# PR 내용

1. `AudioSettingsFragment`의 초기값 반영 방식 개선
- 베이스, 3D 버추얼라이저 초기값을 직접 prefs에서 읽어 세팅하던 흐름을 ViewModel 상태 기반으로 변경
- 프리셋/리버브 spinner 선택 위치를 공유 UiState 기준으로 반영하도록 정리
- Spinner 초기화 중 발생하는 자동 선택 콜백이 저장된 설정을 덮어쓰지 않도록 방지
- Fragment는 UI 연결과 사용자 입력 전달에 집중하도록 역할 축소

2. 리버브 설정을 AudioSettings 상태 관리에 포함
- `AudioSettingsUiState`에 리버브 선택 상태 추가
- 리버브 선택 변경을 `AudioSettingsViewModel`/`AudioSettingsRepository` 경로로 처리
- 저장된 리버브 설정을 앱 시작 또는 오디오 세션 생성 시 함께 복원

3. 불필요한 직접 저장 로직 제거
- 베이스, 3D 버추얼라이저 값을 `onPause`에서 다시 저장하던 중복 로직 제거
- 값 저장과 실제 효과 적용을 `AudioSettingsRepository` 경로로 일원화

4. 이퀄라이저 밴드 관련 변수명을 역할 중심으로 정리해 가독성 개선