### PR TITLE
[ Feature ] 최근 프리셋 목록을 저장/복원하도록 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
@@ -68,9 +68,20 @@ class AudioSettingsRepositoryImpl @Inject constructor(
             AudioSettingsUiState.CUSTOM_PRESET_POSITION,
         )
 
+        // 어떤 화면에서 프리셋을 선택하든 최근 프리셋 목록을 같은 기준으로 갱신한다.
+        val recentPresetPositions = buildRecentPresetPositions(normalizedPresetPosition)
+
         prefs.edit {
             putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
             putInt(AudioSettingKeys.KEY_PRESET, normalizedPresetPosition)
+
+            // Custom은 고정 슬롯으로 처리하므로 일반 EQ 프리셋을 선택했을 때만 최근 목록을 저장한다.
+            if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+                putString(
+                    AudioSettingKeys.KEY_RECENT_PRESET_POSITIONS,
+                    serializeRecentPresetPositions(recentPresetPositions),
+                )
+            }
         }
 
         if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
@@ -221,6 +232,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
                 AudioSettingKeys.KEY_PRESET,
                 AudioSettingsUiState.DEFAULT_PRESET_POSITION,
             ),
+            recentPresetPositions = loadRecentPresetPositions(),
             bassStrength = prefs.getInt(
                 AudioSettingKeys.KEY_BASS,
                 AudioSettingsUiState.DEFAULT_EFFECT_VALUE,
@@ -240,10 +252,67 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         )
     }
 
+    // 선택한 일반 EQ 프리셋을 맨 앞에 두고, 기존 최근 목록을 뒤로 밀어 최신순 목록을 만든다.
+    private fun buildRecentPresetPositions(selectedPresetPosition: Int): List<Int> {
+        if (selectedPresetPosition <= AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+            return loadRecentPresetPositions()
+        }
+
+        val recentPresetPositions = mutableListOf(selectedPresetPosition)
+
+        loadRecentPresetPositions()
+            .filterNot { it == selectedPresetPosition }
+            .forEach { presetPosition ->
+                if (presetPosition !in recentPresetPositions) {
+                    recentPresetPositions += presetPosition
+                }
+            }
+
+        AudioSettingsUiState.DEFAULT_RECENT_PRESET_POSITIONS
+            .filterNot { it == selectedPresetPosition }
+            .forEach { presetPosition ->
+                if (presetPosition !in recentPresetPositions) {
+                    recentPresetPositions += presetPosition
+                }
+            }
+
+        return recentPresetPositions.take(RECENT_NON_CUSTOM_PRESET_COUNT)
+    }
+
+    // 저장된 최근 프리셋 목록을 읽고, 값이 없거나 부족하면 기본 프리셋으로 보충한다.
+    private fun loadRecentPresetPositions(): List<Int> {
+        val savedPresetPositions = prefs.getString(
+            AudioSettingKeys.KEY_RECENT_PRESET_POSITIONS,
+            null,
+        )
+            ?.split(RECENT_PRESET_POSITION_SEPARATOR)
+            ?.mapNotNull { it.toIntOrNull() }
+            .orEmpty()
+
+        return (savedPresetPositions + AudioSettingsUiState.DEFAULT_RECENT_PRESET_POSITIONS)
+            .filter { it > AudioSettingsUiState.CUSTOM_PRESET_POSITION }
+            .distinct()
+            .take(RECENT_NON_CUSTOM_PRESET_COUNT)
+    }
+
+    // SharedPreferences에 저장할 수 있도록 최근 프리셋 position 목록을 문자열로 변환한다.
+    private fun serializeRecentPresetPositions(presetPositions: List<Int>): String {
+        return presetPositions.joinToString(RECENT_PRESET_POSITION_SEPARATOR)
+    }
+
     private companion object {
         const val SETTINGS_PRESET_OFFSET = 1
+
+        // Custom을 제외하고 저장/표시할 일반 EQ 최근 프리셋 개수
+        const val RECENT_NON_CUSTOM_PRESET_COUNT = 3
+
+        // SharedPreferences에 최근 프리셋 position 목록을 저장할 때 사용하는 구분자
+        const val RECENT_PRESET_POSITION_SEPARATOR = ","
+
+        // SeekBar 기반 음향 효과 값은 0~100 범위로 통일한다.
         const val MIN_EFFECT_VALUE = 0
         const val MAX_EFFECT_VALUE = 100
+
         const val MIN_REVERB_PRESET_POSITION = 0
         const val MAX_REVERB_PRESET_POSITION = 6
     }

--- a/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
@@ -3,6 +3,7 @@ package com.hero.ziggymusic.data.local.preferences
 object AudioSettingKeys {
     const val KEY_EQUALIZER_ENABLED = "EQUALIZER_ENABLED"
     const val KEY_PRESET = "PRESET"
+    const val KEY_RECENT_PRESET_POSITIONS = "RECENT_PRESET_POSITIONS" // 바텀시트 최근 프리셋 버튼에 노출할 일반 EQ 프리셋 position 목록
     const val KEY_BASS = "BASS"
     const val KEY_VIRTUALIZER = "VIRTUALIZER"
     const val KEY_REVERB = "REVERB"

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.button.MaterialButton
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
 import com.hero.ziggymusic.databinding.FragmentAudioEffectBottomSheetBinding
@@ -45,12 +46,14 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         R.id.btnRecentPresetFourth,
     )
 
-    private val recentPresets = listOf(
+    private val defaultRecentPresets = listOf(
         AudioEffectPreset.NORMAL,
         AudioEffectPreset.POP,
         AudioEffectPreset.ROCK,
         AudioEffectPreset.CUSTOM,
     )
+
+    private var recentPresets = defaultRecentPresets
 
     override fun getTheme(): Int = R.style.PlayerBottomSheet
 
@@ -181,12 +184,52 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
             binding.seekBarVirtualizer.progress = state.virtualizerStrength
         }
 
+        // 저장소에 저장된 최근 프리셋 순서를 버튼 라벨에 반영한다.
+        updateRecentPresetButtons(state.recentPresetPositions)
+
         val checkedButtonId = findPresetButtonId(state.currentPresetPosition)
         if (checkedButtonId != null && binding.togglePresetGroup.checkedButtonId != checkedButtonId) {
             binding.togglePresetGroup.check(checkedButtonId)
         }
 
         isApplyingAudioSettingsState = false
+    }
+
+    // 최근 프리셋 position 목록을 버튼 모델로 변환하고 각 MaterialButton의 표시 텍스트를 갱신한다.
+    private fun updateRecentPresetButtons(recentPresetPositions: List<Int>) {
+        recentPresets = buildRecentPresetButtonModels(recentPresetPositions)
+
+        recentPresetButtonIds.forEachIndexed { index, buttonId ->
+            val preset = recentPresets.getOrNull(index) ?: return@forEachIndexed
+            binding.togglePresetGroup.findViewById<MaterialButton>(buttonId)?.text =
+                getString(preset.labelResId)
+        }
+    }
+
+    // Custom은 사용자가 직접 조정한 EQ 상태를 되돌리는 진입점이므로 마지막 버튼에 고정하고,
+    // 일반 EQ 프리셋만 최근 선택 순서대로 앞 3개 버튼에 배치한다.
+    private fun buildRecentPresetButtonModels(
+        recentPresetPositions: List<Int>,
+    ): List<AudioEffectPreset> {
+        // 저장된 position 값을 바텀시트 프리셋 모델로 변환한 일반 EQ 프리셋 목록
+        val nonCustomPresets = recentPresetPositions
+            .mapNotNull(::findPresetBySettingsPosition)
+            .filterNot { it == AudioEffectPreset.CUSTOM }
+            .distinct()
+
+        // 저장된 목록이 부족하거나 유효하지 않을 때 빈 슬롯을 채울 기본 프리셋 후보
+        val fallbackPresets = defaultRecentPresets
+            .filterNot { it == AudioEffectPreset.CUSTOM || it in nonCustomPresets }
+
+        return (nonCustomPresets + fallbackPresets)
+            .take(RECENT_NON_CUSTOM_PRESET_COUNT) + AudioEffectPreset.CUSTOM
+    }
+
+    // 설정 화면의 spinner position 값에 대응하는 바텀시트 프리셋 모델을 찾는다.
+    private fun findPresetBySettingsPosition(presetPosition: Int): AudioEffectPreset? {
+        return AudioEffectPreset.entries.firstOrNull {
+            it.config.settingsPresetPosition == presetPosition
+        }
     }
 
     // 현재 프리셋 position에 대응하는 바텀시트 버튼 id를 찾는다.
@@ -225,10 +268,13 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
     companion object {
         const val TAG = "AudioEffectBottomSheetDialogFragment"
 
-        // Fragment Result로 PlayerFragment에 전달할 바텀시트 액션 정보.
+        // Fragment Result로 PlayerFragment에 전달할 바텀시트 액션 정보
         const val REQUEST_KEY = "audio_effect_bottom_sheet_request"
         const val RESULT_ACTION_KEY = "audio_effect_bottom_sheet_action"
         const val ACTION_OPEN_AUDIO_SETTINGS = "open_audio_settings"
+
+        // 바텀시트 최근 프리셋 버튼 중 Custom을 제외한 일반 EQ 프리셋 슬롯 개수
+        private const val RECENT_NON_CUSTOM_PRESET_COUNT = 3
 
         // SeekBar 기반 음향 효과 값은 0~100 범위로 통일한다.
         private const val MIN_EFFECT_VALUE = 0

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
@@ -9,6 +9,7 @@ package com.hero.ziggymusic.presentation.main.setting.model
 data class AudioSettingsUiState(
     val isEqualizerEnabled: Boolean = false,
     val currentPresetPosition: Int = DEFAULT_PRESET_POSITION,
+    val recentPresetPositions: List<Int> = DEFAULT_RECENT_PRESET_POSITIONS,
     val bassStrength: Int = DEFAULT_EFFECT_VALUE,
     val virtualizerStrength: Int = DEFAULT_EFFECT_VALUE,
     val reverbPresetPosition: Int = DEFAULT_REVERB_PRESET_POSITION,
@@ -25,5 +26,15 @@ data class AudioSettingsUiState(
         const val DEFAULT_REVERB_PRESET_POSITION = 0
 
         const val DEFAULT_EFFECT_VALUE = 0
+
+        private const val POP_PRESET_POSITION = 9
+        private const val ROCK_PRESET_POSITION = 10
+
+        // 저장된 최근 프리셋이 없을 때 사용하는 기본 일반 EQ 프리셋 목록
+        val DEFAULT_RECENT_PRESET_POSITIONS = listOf(
+            DEFAULT_PRESET_POSITION,
+            POP_PRESET_POSITION,
+            ROCK_PRESET_POSITION,
+        )
     }
 }


### PR DESCRIPTION
# PR 내용
1. 최근 프리셋 상태 관리 위치 변경
- 바텀시트 내부 로컬 변수로만 관리하던 최근 프리셋 목록을 `AudioSettingsRepository` 상태로 이동
- 음향 설정 화면 스피너와 바텀시트 버튼 중 어디서 프리셋을 선택해도 동일한 최근 프리셋 목록이 갱신되도록 개선

2. 최근 프리셋 저장 및 복원 처리 추가
- 일반 EQ 프리셋 position 목록을 `SharedPreferences`에 저장하도록 추가
- 앱 재실행 또는 바텀시트 재생성 후에도 최근 프리셋 순서가 유지되도록 보완

3. 바텀시트 표시 로직 정리
- 저장소에서 전달된 최근 프리셋 목록을 기준으로 버튼 라벨을 갱신하도록 변경
- `Custom`은 마지막 슬롯에 고정하고, 일반 EQ 프리셋만 최신순으로 앞 3개 슬롯에 표시