### PR TITLE
[ Fix ] 음향 설정 화면에서 프리셋 선택 시 EQ 밴드 SeekBar 동기화되지 않는 버그 해결

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
@@ -86,6 +86,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
 
         if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
             AudioEffectManager.useEqualizerPreset(normalizedPresetPosition - SETTINGS_PRESET_OFFSET)
+            applyCurrentEqualizerBandsToDsp()
         }
 
         AudioEffectManager.setEnabledFromPrefs(prefs)
@@ -134,7 +135,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         return (normalized * 24.0f) - 12.0f
     }
 
-    // EQ 밴드 직접 조작만 Custom 전환 조건으로 사용한다.
+    // 사용자가 EQ 밴드를 직접 조정하면 현재 프리셋을 Custom으로 전환하고 전체 밴드 값을 저장/적용한다.
     override fun updateEqualizerBandFromUser(
         bandIndex: Int,
         progress: Int,
@@ -143,30 +144,62 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         val minBandLevel = bandLevelRange[0].toInt()
         val maxBandLevel = bandLevelRange[1].toInt()
         val maxBandProgress = maxBandLevel - minBandLevel
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
+
+        if (bandIndex !in 0 until numberOfBands) return
 
         val clampedProgress = progress.coerceIn(0, maxBandProgress)
 
-        // SeekBar progress를 Android Equalizer가 요구하는 band level 값으로 변환한다.
-        val nativeBandLevel = (clampedProgress + minBandLevel).toShort()
-        val gainDb = mapEqProgressToDb(
-            progress = clampedProgress,
-            max = maxBandProgress,
-        )
+        // 일반 프리셋에서 Custom으로 전환될 때 나머지 밴드가 이전 Custom 값으로 튀지 않도록 현재 EQ 값을 기준으로 시작한다.
+        val customBandProgresses = loadCurrentEqualizerBandProgresses(
+            minBandLevel = minBandLevel,
+            maxBandProgress = maxBandProgress,
+        ).toMutableList()
+
+        customBandProgresses[bandIndex] = clampedProgress
 
         prefs.edit {
             putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
             putInt(AudioSettingKeys.KEY_PRESET, AudioSettingsUiState.CUSTOM_PRESET_POSITION)
-            putInt(bandIndex.toString(), clampedProgress)
+
+            // Custom 복원에 사용할 전체 EQ 밴드 progress를 SharedPreferences에 저장한다.
+            customBandProgresses.forEachIndexed { index, bandProgress ->
+                putInt(index.toString(), bandProgress)
+            }
         }
 
-        AudioEffectManager.applyEqualizerBandLevel(
-            bandIndex = bandIndex,
-            level = nativeBandLevel,
-        )
-        AudioEffectManager.setBandGain(bandIndex, gainDb)
-        AudioEffectManager.setEnabledFromPrefs(prefs)
+        // 저장한 Custom 밴드 값을 Android Equalizer와 DSP EQ 양쪽에 즉시 반영한다.
+        customBandProgresses.forEachIndexed { index, bandProgress ->
+            val nativeBandLevel = (bandProgress + minBandLevel).toShort()
+            val gainDb = mapEqProgressToDb(
+                progress = bandProgress,
+                max = maxBandProgress,
+            )
 
+            AudioEffectManager.applyEqualizerBandLevel(
+                bandIndex = index,
+                level = nativeBandLevel,
+            )
+            AudioEffectManager.setBandGain(index, gainDb)
+        }
+
+        AudioEffectManager.setEnabledFromPrefs(prefs)
         updateStateFromStorage()
+    }
+
+    // 현재 Android Equalizer의 band level을 UI progress로 변환해 Custom 저장의 기준값으로 사용한다.
+    private fun loadCurrentEqualizerBandProgresses(
+        minBandLevel: Int,
+        maxBandProgress: Int,
+    ): List<Int> {
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
+
+        return (0 until numberOfBands).map { bandIndex ->
+            val nativeBandLevel = AudioEffectManager.getBandLevel(bandIndex)?.toInt()
+                ?: (prefs.getInt(bandIndex.toString(), 0) + minBandLevel)
+
+            (nativeBandLevel - minBandLevel).coerceIn(0, maxBandProgress)
+        }
     }
 
     // BassBoost 값은 EQ 프리셋 선택 상태를 유지한 채 별도로 저장한다.
@@ -226,12 +259,15 @@ class AudioSettingsRepositoryImpl @Inject constructor(
 
     // SharedPreferences에 저장된 값을 UI 상태 모델로 변환
     private fun loadAudioSettingsState(): AudioSettingsUiState {
+        val currentPresetPosition = prefs.getInt(
+            AudioSettingKeys.KEY_PRESET,
+            AudioSettingsUiState.DEFAULT_PRESET_POSITION,
+        )
+
         return AudioSettingsUiState(
             isEqualizerEnabled = prefs.getBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, false),
-            currentPresetPosition = prefs.getInt(
-                AudioSettingKeys.KEY_PRESET,
-                AudioSettingsUiState.DEFAULT_PRESET_POSITION,
-            ),
+            currentPresetPosition = currentPresetPosition,
+            equalizerBandProgresses = loadEqualizerBandProgresses(currentPresetPosition),
             recentPresetPositions = loadRecentPresetPositions(),
             bassStrength = prefs.getInt(
                 AudioSettingKeys.KEY_BASS,
@@ -250,6 +286,39 @@ class AudioSettingsRepositoryImpl @Inject constructor(
                 false,
             ),
         )
+    }
+
+    private fun loadEqualizerBandProgresses(currentPresetPosition: Int): List<Int> {
+        val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return emptyList()
+        val minBandLevel = bandLevelRange[0].toInt()
+        val maxBandProgress = bandLevelRange[1].toInt() - minBandLevel
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
+
+        return if (currentPresetPosition == AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
+            (0 until numberOfBands).map { bandIndex ->
+                prefs.getInt(bandIndex.toString(), 0).coerceIn(0, maxBandProgress)
+            }
+        } else {
+            (0 until numberOfBands).map { bandIndex ->
+                val nativeBandLevel = AudioEffectManager.getBandLevel(bandIndex)?.toInt() ?: 0
+                (nativeBandLevel - minBandLevel).coerceIn(0, maxBandProgress)
+            }
+        }
+    }
+
+    private fun applyCurrentEqualizerBandsToDsp() {
+        val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
+        val minBandLevel = bandLevelRange[0].toInt()
+        val maxBandProgress = bandLevelRange[1].toInt() - minBandLevel
+        val numberOfBands = AudioEffectManager.getNumberOfBands()
+
+        for (bandIndex in 0 until numberOfBands) {
+            val nativeBandLevel = AudioEffectManager.getBandLevel(bandIndex)?.toInt() ?: continue
+            val progress = (nativeBandLevel - minBandLevel).coerceIn(0, maxBandProgress)
+            val gainDb = mapEqProgressToDb(progress, maxBandProgress)
+
+            AudioEffectManager.setBandGain(bandIndex, gainDb)
+        }
     }
 
     // 선택한 일반 EQ 프리셋을 맨 앞에 두고, 기존 최근 목록을 뒤로 밀어 최신순 목록을 만든다.

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -9,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
-import androidx.core.content.edit
 import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -22,8 +21,6 @@ import com.google.android.material.button.MaterialButton
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
 import com.hero.ziggymusic.databinding.FragmentAudioEffectBottomSheetBinding
-import com.hero.ziggymusic.playback.manager.AudioEffectManager
-import com.hero.ziggymusic.presentation.main.setting.AudioSettingsFragment
 import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
 import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -276,15 +276,6 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         // 바텀시트 최근 프리셋 버튼 중 Custom을 제외한 일반 EQ 프리셋 슬롯 개수
         private const val RECENT_NON_CUSTOM_PRESET_COUNT = 3
 
-        // SeekBar 기반 음향 효과 값은 0~100 범위로 통일한다.
-        private const val MIN_EFFECT_VALUE = 0
-        private const val MAX_EFFECT_VALUE = 100
-        private const val DEFAULT_EFFECT_VALUE = 0
-
-        // AudioSettingsFragment의 프리셋 목록은 0번을 Custom으로 사용한다.
-        private const val CUSTOM_PRESET_POSITION = 0
-        private const val SETTINGS_PRESET_OFFSET = 1
-
         fun newInstance(): AudioEffectBottomSheetDialogFragment =
             AudioEffectBottomSheetDialogFragment()
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -230,6 +230,8 @@ class AudioSettingsFragment : Fragment() {
             binding.spinnerPreset.setSelection(state.currentPresetPosition)
         }
 
+        updateEqualizerBandSeekBars(state.equalizerBandProgresses)
+
         // Reverb 선택 위치도 공유 상태를 기준으로 맞춘다.
         if (binding.spinnerReverb.adapter != null &&
             binding.spinnerReverb.selectedItemPosition != state.reverbPresetPosition
@@ -343,7 +345,7 @@ class AudioSettingsFragment : Fragment() {
                     progress: Int,
                     fromUser: Boolean,
                 ) {
-                    if (!fromUser || isApplyingAudioSettingsState) return
+                    if (!isEqualizerBandChangedByUser(seekBar, fromUser) || isApplyingAudioSettingsState) return
 
                     // EQ 밴드 직접 조작은 Custom 프리셋 전환 조건이다.
                     vm.updateEqualizerBandFromUser(
@@ -396,6 +398,35 @@ class AudioSettingsFragment : Fragment() {
 
         initPresets()
         updateEqualizerUiState(binding.swEqualizer.isChecked)
+    }
+
+    private fun updateEqualizerBandSeekBars(equalizerBandProgresses: List<Int>) {
+        if (equalizerBandProgresses.isEmpty()) return
+
+        for (index in 0 until binding.seekbarContainer.childCount) {
+            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? SoundEQVerticalSeekbar
+                ?: continue
+
+            val progress = equalizerBandProgresses.getOrNull(index)
+                ?.coerceIn(0, equalizerBandSeekBar.max)
+                ?: continue
+
+            if (equalizerBandSeekBar.progress != progress) {
+                equalizerBandSeekBar.progress = progress
+                equalizerBandSeekBar.refreshThumbState()
+            }
+        }
+    }
+
+    // SoundEQVerticalSeekbar는 터치를 직접 처리하므로 fromUser 대신 tracking 상태도 함께 확인한다.
+    private fun isEqualizerBandChangedByUser(
+        seekBar: SeekBar,
+        fromUser: Boolean,
+    ): Boolean {
+        val isVerticalSeekBarTracking =
+            (seekBar as? SoundEQVerticalSeekbar)?.isTrackingTouch == true
+
+        return fromUser || isVerticalSeekBarTracking
     }
 
     private fun updateEqualizerUiState(isEnabled: Boolean) {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -32,7 +32,7 @@ import com.hero.ziggymusic.playback.manager.AudioEffectManager
 import com.hero.ziggymusic.playback.manager.AudioEffectManager.mainColor
 import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
 import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
-import com.hero.ziggymusic.presentation.main.setting.widget.SoundEQVerticalSeekbar
+import com.hero.ziggymusic.presentation.main.setting.widget.EqualizerBandSeekBar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.util.Locale
@@ -326,7 +326,7 @@ class AudioSettingsFragment : Fragment() {
         val numberOfBands = AudioEffectManager.getNumberOfBands()
 
         for (index in 0 until numberOfBands) {
-            val equalizerBandSeekBar = SoundEQVerticalSeekbar(requireContext())
+            val equalizerBandSeekBar = EqualizerBandSeekBar(requireContext())
 
             equalizerBandSeekBarIds.add(index, View.generateViewId())
 
@@ -414,7 +414,7 @@ class AudioSettingsFragment : Fragment() {
         if (equalizerBandProgresses.isEmpty()) return
 
         for (index in 0 until binding.seekbarContainer.childCount) {
-            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? SoundEQVerticalSeekbar
+            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? EqualizerBandSeekBar
                 ?: continue
 
             val progress = equalizerBandProgresses.getOrNull(index)
@@ -434,7 +434,7 @@ class AudioSettingsFragment : Fragment() {
         fromUser: Boolean,
     ): Boolean {
         val isVerticalSeekBarTracking =
-            (seekBar as? SoundEQVerticalSeekbar)?.isTrackingTouch == true
+            (seekBar as? EqualizerBandSeekBar)?.isTrackingTouch == true
 
         return fromUser || isVerticalSeekBarTracking
     }
@@ -457,7 +457,7 @@ class AudioSettingsFragment : Fragment() {
         binding.tvSeekbar.alpha = contentAlpha
 
         for (index in 0 until binding.seekbarContainer.childCount) {
-            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? SoundEQVerticalSeekbar
+            val equalizerBandSeekBar = binding.seekbarContainer.getChildAt(index) as? EqualizerBandSeekBar
                 ?: continue
 
             equalizerBandSeekBar.isEnabled = isEnabled

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -53,7 +53,7 @@ class AudioSettingsFragment : Fragment() {
 
     private lateinit var prefs: SharedPreferences
 
-    // XR / Spatial Audio Components
+    // XR / Spatial Audio 컴포넌트
     private lateinit var headTracker: HeadTracker
     private lateinit var spatializerSupport: SpatializerSupport
 
@@ -100,7 +100,7 @@ class AudioSettingsFragment : Fragment() {
         binding.swSpatialAudio.setOnCheckedChangeListener(null)
         binding.swHeadTracking.setOnCheckedChangeListener(null)
 
-        // 1. Spatial Audio & Head Tracking Enable Switch
+        // 1. Spatial Audio & Head Tracking 활성화 스위치
         val spatialEnabled = prefs.getBoolean(AudioSettingKeys.KEY_SPATIAL_ENABLED, false)
         val headEnabled = prefs.getBoolean(AudioSettingKeys.KEY_HEAD_TRACKING_ENABLED, false)
 
@@ -115,10 +115,16 @@ class AudioSettingsFragment : Fragment() {
             AudioEffectManager.setHeadTrackingEnabled(spatialEnabled && headEnabled)
 
             if (spatialEnabled && headEnabled) {
-                PlayerAudioGraph.setHeadTrackingActive(true, true)
+                PlayerAudioGraph.setHeadTrackingActive(
+                    spatialEnabled = true,
+                    headTrackingEnabled = true
+                )
                 headTracker.start()
             } else {
-                PlayerAudioGraph.setHeadTrackingActive(false, false)
+                PlayerAudioGraph.setHeadTrackingActive(
+                    spatialEnabled = false,
+                    headTrackingEnabled = false
+                )
                 headTracker.stop()
             }
         }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -472,7 +472,7 @@ class AudioSettingsFragment : Fragment() {
         }
     }
 
-    // SettingsFragment의 progress 범위를 기준으로 dB로 환산
+    // EQ SeekBar progress(0..max)를 DSP EQ gain 범위(-12dB..+12dB)에 맞춰 변환한다.
     private fun mapEqProgressToDb(progress: Int, max: Int): Float {
         if (max <= 0) return 0.0f
         val normalized = (progress.toFloat() / max.toFloat()).coerceIn(0.0f, 1.0f) // 0..1

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -80,9 +80,9 @@ class AudioSettingsFragment : Fragment() {
         initSetting()
 
         initEqualizer()
-        initBassSeekBar(prefs)
         initReverb()
         initLoudnessNormalizer()
+        initBassSeekBar()
         initVirtualizerSeekbar()
         initSpatialAudioUi() // XR 기능 UI 설정
         observeAudioSettingsState()
@@ -531,7 +531,7 @@ class AudioSettingsFragment : Fragment() {
         }
     }
 
-    private fun initBassSeekBar(settings: SharedPreferences) {
+    private fun initBassSeekBar() {
         binding.sbBass.progressDrawable.setTint(mainColor)
         binding.sbBass.thumb.setTint(mainColor)
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AudioSettingsFragment.kt
@@ -85,6 +85,10 @@ class AudioSettingsFragment : Fragment() {
         initBassSeekBar()
         initVirtualizerSeekbar()
         initSpatialAudioUi() // XR 기능 UI 설정
+        setupAudioSettingsState()
+    }
+
+    private fun setupAudioSettingsState() {
         observeAudioSettingsState()
         vm.refreshSettings()
     }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/model/AudioSettingsUiState.kt
@@ -9,6 +9,7 @@ package com.hero.ziggymusic.presentation.main.setting.model
 data class AudioSettingsUiState(
     val isEqualizerEnabled: Boolean = false,
     val currentPresetPosition: Int = DEFAULT_PRESET_POSITION,
+    val equalizerBandProgresses: List<Int> = emptyList(),
     val recentPresetPositions: List<Int> = DEFAULT_RECENT_PRESET_POSITIONS,
     val bassStrength: Int = DEFAULT_EFFECT_VALUE,
     val virtualizerStrength: Int = DEFAULT_EFFECT_VALUE,

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/widget/EqualizerBandSeekBar.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/widget/EqualizerBandSeekBar.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.widget.AppCompatSeekBar
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.withRotation
 
-class SoundEQVerticalSeekbar @JvmOverloads constructor(
+class EqualizerBandSeekBar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.seekBarStyle,


### PR DESCRIPTION
# PR 내용
1. EQ 밴드 progress 상태 추가
- 현재 선택된 프리셋의 EQ 밴드 progress 목록을 `AudioSettingsUiState`에 포함
- 프리셋 변경 후 설정 화면이 5개 EQ SeekBar 상태를 다시 그릴 수 있도록 개선

2. 프리셋 적용 후 밴드 값 동기화
- 일반 EQ 프리셋 선택 시 `Equalizer`의 현재 band level을 읽어 UI progress로 변환
- 프리셋 band level을 DSP EQ 값에도 반영해 실제 효과와 UI 표시가 어긋나지 않도록 보완

3. 설정 화면 SeekBar 렌더링 개선
- `AudioSettingsFragment`에서 상태로 전달된 EQ 밴드 progress를 5개 SeekBar thumb에 반영
- 프리셋 선택으로 인한 자동 SeekBar 갱신은 사용자 조작으로 처리되지 않도록 기존 방어 로직 유지

4. EQ progress 변환 로직 문서화
- `mapEqProgressToDb()`에 UI progress를 DSP EQ gain 범위로 변환한다는 주석 추가
- `SoundEQVerticalSeekbar` 이름을 `EqualizerBandSeekBar`로 변경

5. `AudioSettingsFragment` 내 음향 설정 상태 초기화 로직 분리

6. `AudioEffectBottomSheetDialogFragment` 내 불필요한 import문, 상수 제거

7. Head Tracker, Spatializer 관련 파라미터 명시 및 주석 보완