### PR TITLE
[ Feature ] 이용약관 및 개인정보처리방침 WebView 화면 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".ZiggyMusicApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
+++ b/app/src/main/java/com/hero/ziggymusic/ZiggyMusicApp.kt
@@ -2,7 +2,6 @@ package com.hero.ziggymusic
 
 import android.app.Application
 import android.app.NotificationManager
-import com.hero.ziggymusic.playback.audio.AudioDspChainHolder
 import com.hero.ziggymusic.playback.service.MusicService
 import com.hero.ziggymusic.playback.service.MusicServiceState
 import dagger.hilt.android.HiltAndroidApp
@@ -27,14 +26,6 @@ class ZiggyMusicApp : Application() {
             }
             defaultExceptionHandler?.uncaughtException(thread, throwable)
         }
-
-        runCatching { AudioDspChainHolder.ensureNativeDspChainInitialized(this) }
-    }
-
-    override fun onTerminate() {
-        super.onTerminate()
-        // 에뮬/디버그에서만 호출될 수 있지만, 정리 루틴은 두는 편이 안전
-        AudioDspChainHolder.releaseNativeChain()
     }
 
     private fun cancelStaleMusicNotification() {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -52,6 +52,7 @@ import com.hero.ziggymusic.presentation.main.player.manager.PlayerController
 import com.hero.ziggymusic.presentation.main.player.manager.PlayerMotionManager
 import com.hero.ziggymusic.presentation.main.player.viewmodel.PlayerViewModel
 import com.hero.ziggymusic.presentation.main.setting.AppSettingsFragment
+import com.hero.ziggymusic.presentation.main.setting.WebPageFragment
 import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -133,6 +134,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                 is FavoriteMusicTracksFragment -> vm.setTitle(MainTitle.FavoriteTracks)
                 is AppSettingsFragment -> vm.setTitle(MainTitle.AppSettings)
                 is AudioSettingsFragment -> vm.setTitle(MainTitle.AudioSettings)
+                is WebPageFragment -> vm.setTitle(MainTitle.WebPage(currentFragment.titleResId))
             }
         }
 
@@ -247,6 +249,53 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             .commit()
     }
 
+    private fun showWebPageFragment(
+        tag: String,
+        url: String,
+        titleResId: Int,
+    ) {
+        val existingWebPageFragment = supportFragmentManager.findFragmentByTag(tag)
+
+        if (
+            existingWebPageFragment != null &&
+            existingWebPageFragment.isAdded &&
+            !existingWebPageFragment.isHidden
+        ) {
+            return
+        }
+
+        var appSettingsFragment = supportFragmentManager.findFragmentByTag(TAG_APP_SETTINGS)
+
+        if (appSettingsFragment == null) {
+            showAppSettingsFragment()
+            supportFragmentManager.executePendingTransactions()
+
+            appSettingsFragment = supportFragmentManager.findFragmentByTag(TAG_APP_SETTINGS) ?: return
+        }
+
+        val webPageFragment =
+            existingWebPageFragment ?: WebPageFragment.newInstance(
+                url = url,
+                titleResId = titleResId
+            )
+
+        supportFragmentManager.beginTransaction()
+            .setReorderingAllowed(true)
+            .hide(appSettingsFragment)
+            .setMaxLifecycle(appSettingsFragment, Lifecycle.State.STARTED)
+            .apply {
+                if (webPageFragment.isAdded) {
+                    show(webPageFragment)
+                } else {
+                    add(binding.fcvMain.id, webPageFragment, tag)
+                }
+            }
+            .setMaxLifecycle(webPageFragment, Lifecycle.State.RESUMED)
+            .setPrimaryNavigationFragment(webPageFragment)
+            .addToBackStack(tag)
+            .commit()
+    }
+
     override fun onStart() {
         super.onStart()
     }
@@ -277,6 +326,16 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                 when (event.getContentIfNotHandled()) {
                     MainNavigationCommand.AppSettings -> showAppSettingsFragment()
                     MainNavigationCommand.AudioSettings -> showAudioSettingsFragment()
+                    MainNavigationCommand.TermsOfService -> showWebPageFragment(
+                        tag = TAG_TERMS_OF_SERVICE,
+                        url = TERMS_OF_SERVICE_URL,
+                        titleResId = R.string.settings_terms_of_service
+                    )
+                    is MainNavigationCommand.PrivacyPolicy -> showWebPageFragment(
+                        tag = TAG_PRIVACY_POLICY,
+                        url = PRIVACY_POLICY_URL,
+                        titleResId = R.string.settings_privacy_policy
+                    )
                     null -> Unit
                 }
             }
@@ -763,5 +822,13 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         private const val TAG_FAVORITES = "favorites"
         private const val TAG_APP_SETTINGS = "app_settings"
         private const val TAG_AUDIO_SETTINGS = "audio_settings"
+        private const val TAG_PRIVACY_POLICY = "privacy_policy"
+        private const val TAG_TERMS_OF_SERVICE = "terms_of_service"
+
+        private const val PRIVACY_POLICY_URL =
+            "https://thsamajiki.github.io/ziggymusic-privacy-policy.html"
+
+        private const val TERMS_OF_SERVICE_URL =
+            "https://thsamajiki.github.io/ziggymusic-terms-of-service.html"
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainViewModel.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
 sealed class MainNavigationCommand {
     object AppSettings : MainNavigationCommand()
     object AudioSettings : MainNavigationCommand()
+    object TermsOfService : MainNavigationCommand()
+    object PrivacyPolicy : MainNavigationCommand()
 }
 
 @HiltViewModel
@@ -34,6 +36,14 @@ class MainViewModel @Inject constructor(
 
     fun requestOpenAudioSettings() {
         _navigationEvent.value = SingleEvent(MainNavigationCommand.AudioSettings)
+    }
+
+    fun requestTermsOfService() {
+        _navigationEvent.value = SingleEvent(MainNavigationCommand.TermsOfService)
+    }
+
+    fun requestOpenPrivacyPolicy() {
+        _navigationEvent.value = SingleEvent(MainNavigationCommand.PrivacyPolicy)
     }
 
     fun setTitle(title: MainTitle) {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/model/MainTitle.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/model/MainTitle.kt
@@ -21,4 +21,12 @@ sealed class MainTitle(
         showBackButton = true,
         showAppSettingsButton = false
     )
+
+    data class WebPage(
+        @param:StringRes val titleResId: Int,
+    ) : MainTitle(
+        resId = titleResId,
+        showBackButton = true,
+        showAppSettingsButton = false
+    )
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AppSettingsFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/AppSettingsFragment.kt
@@ -44,9 +44,11 @@ class AppSettingsFragment : Fragment() {
         }
 
         binding.rowTermsOfService.setOnClickListener {
+            mainVm.requestTermsOfService()
         }
 
         binding.rowPrivacyPolicy.setOnClickListener {
+            mainVm.requestOpenPrivacyPolicy()
         }
 
         binding.rowOpenSourceLicenses.setOnClickListener {

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/WebPageFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/setting/WebPageFragment.kt
@@ -1,0 +1,74 @@
+package com.hero.ziggymusic.presentation.main.setting
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebViewClient
+import com.hero.ziggymusic.databinding.FragmentWebPageBinding
+
+/**
+ * 이용약관, 개인정보처리방침, 오픈소스 라이선스와 같은
+ * 정적 웹 문서를 앱 내부 WebView로 표시하는 Fragment.
+ *
+ * 표시할 URL과 제목은 [newInstance]를 통해 전달받으며,
+ * 보안상 JavaScript와 파일 접근 등 불필요한 WebView 기능은 비활성화한다.
+ */
+class WebPageFragment : Fragment() {
+    private var _binding: FragmentWebPageBinding? = null
+    private val binding get() = _binding!!
+
+    val titleResId: Int
+        get() = requireArguments().getInt(ARG_WEB_PAGE_TITLE_RES_ID)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentWebPageBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.webView.apply {
+            webViewClient = WebViewClient()
+
+            settings.apply {
+                javaScriptEnabled = false
+                domStorageEnabled = false
+                allowFileAccess = false
+                allowContentAccess = false
+            }
+
+            loadUrl(requireArguments().getString(ARG_WEB_PAGE_URL).orEmpty())
+        }
+    }
+
+    override fun onDestroyView() {
+        binding.webView.destroy()
+        _binding = null
+        super.onDestroyView()
+    }
+
+    companion object {
+        private const val ARG_WEB_PAGE_URL = "web_page_url"
+        private const val ARG_WEB_PAGE_TITLE_RES_ID = "web_page_title_res_id"
+
+        /**
+         * 지정한 URL과 제목으로 [WebPageFragment] 인스턴스를 생성한다.
+         */
+        fun newInstance(
+            url: String,
+            titleResId: Int,
+        ): WebPageFragment {
+            return WebPageFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_WEB_PAGE_URL, url)
+                    putInt(ARG_WEB_PAGE_TITLE_RES_ID, titleResId)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_web_page.xml
+++ b/app/src/main/res/layout/fragment_web_page.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.main.setting.WebPageFragment">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>


### PR DESCRIPTION
# PR 내용
1. 이용약관/개인정보처리방침 WebView 표시 기능 추가
  - 설정 화면의 이용약관 및 개인정보처리방침 메뉴 클릭 시 웹 페이지 화면으로 이동하도록 연결
  - `WebPageFragment`와 `fragment_web_page.xml`을 추가해 외부 약관 페이지를 앱 내 WebView로 표시

2. WebPage 화면 네비게이션 및 타이틀 처리
  - `MainViewModel`에 이용약관/개인정보처리방침 이동 커맨드 추가
  - `MainActivity`에서 `WebPageFragment` 전환, 백스택, 공통 툴바 타이틀 상태를 처리
  - `MainTitle.WebPage`를 추가해 WebView 화면에서도 뒤로가기 버튼과 화면 제목이 정상 표시되도록 개선

3. WebView 사용을 위한 권한 및 실행 안정성 보완
  - 외부 약관 페이지 로드를 위해 INTERNET 권한 추가
  - 앱 시작 직후 native DSP를 선초기화하지 않도록 정리해 실행 초기 크래시 가능성 완화