### PR TITLE
[ Feature ] 음악 트랙 목록 정렬 및 정렬 상태 저장/복원 기능 추가

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/local/dao/FavoriteMusicTracksDao.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/dao/FavoriteMusicTracksDao.kt
@@ -12,8 +12,11 @@ interface FavoriteMusicTracksDao {
         FROM music_tracks
         INNER JOIN favorite_music_tracks
         ON music_tracks.id = favorite_music_tracks.id
-        ORDER BY favorite_music_tracks.created_at DESC
-    """)
+        ORDER BY
+            favorite_music_tracks.created_at ASC,
+            favorite_music_tracks.id ASC
+        """
+    )
     fun getFavoriteMusicTracks(): LiveData<List<MusicTrackEntity>>
 
     @Query("SELECT id FROM favorite_music_tracks")

--- a/app/src/main/java/com/hero/ziggymusic/data/local/entity/MusicTrackEntity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/entity/MusicTrackEntity.kt
@@ -25,6 +25,8 @@ data class MusicTrackEntity(
     val album: String? = "",    // 앨범명
     @ColumnInfo(name = "duration")
     val duration: Long? = 0,     // 음원 재생 시간
+    @ColumnInfo(name = "date_added")
+    val dateAdded: Long,    // MediaStore에 추가된 시각(초 단위)
     @ColumnInfo(name = "is_playing")
     val isPlaying: Boolean = false,
 ) : Parcelable {

--- a/app/src/main/java/com/hero/ziggymusic/data/local/preferences/MusicTracksSortStore.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/preferences/MusicTracksSortStore.kt
@@ -1,0 +1,51 @@
+package com.hero.ziggymusic.data.local.preferences
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hero.ziggymusic.domain.music.model.MusicTracksSortOrder
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class MusicTracksSortStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val prefs = context.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    fun loadMusicTracksSortOrder(): MusicTracksSortOrder {
+        val savedSortOrderName = prefs.getString(
+            KEY_MUSIC_TRACKS_SORT_ORDER,
+            null
+        )
+
+        // 저장값이 없거나 유효하지 않으면 제목 오름차순을 사용한다.
+        return savedSortOrderName
+            ?.let { sortOrderName ->
+                runCatching {
+                    MusicTracksSortOrder.valueOf(sortOrderName)
+                }.getOrNull()
+            }
+            ?: MusicTracksSortOrder.TITLE_ASCENDING
+    }
+
+    fun saveMusicTracksSortOrder(
+        sortOrder: MusicTracksSortOrder,
+    ) {
+        prefs.edit {
+            putString(
+                KEY_MUSIC_TRACKS_SORT_ORDER,
+                sortOrder.name
+            )
+        }
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME =
+            "ziggymusic_music_tracks_sort_preferences"
+
+        const val KEY_MUSIC_TRACKS_SORT_ORDER =
+            "music_tracks_sort_order"
+    }
+}

--- a/app/src/main/java/com/hero/ziggymusic/data/music/source/MusicLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/music/source/MusicLocalDataSourceImpl.kt
@@ -33,7 +33,8 @@ class MusicLocalDataSourceImpl @Inject constructor(
                 MediaStore.Audio.Media.ARTIST,
                 MediaStore.Audio.Media.ALBUM_ID,
                 MediaStore.Audio.Media.ALBUM,
-                MediaStore.Audio.Media.DURATION
+                MediaStore.Audio.Media.DURATION,
+                MediaStore.Audio.Media.DATE_ADDED
             )
 
             val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} > 0"
@@ -56,6 +57,7 @@ class MusicLocalDataSourceImpl @Inject constructor(
                 val albumIdColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
                 val albumTitleColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
                 val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+                val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
 
                 while (cursor.moveToNext()) {
                     val musicTrack = MusicTrackEntity(
@@ -64,7 +66,8 @@ class MusicLocalDataSourceImpl @Inject constructor(
                         artist = cursor.getString(artistColumn),
                         albumId = cursor.getString(albumIdColumn),
                         album = cursor.getString(albumTitleColumn),
-                        duration = cursor.getLong(durationColumn)
+                        duration = cursor.getLong(durationColumn),
+                        dateAdded = cursor.getLong(dateAddedColumn)
                     )
 
                     musicTrackList.add(musicTrack)

--- a/app/src/main/java/com/hero/ziggymusic/domain/music/model/MusicTracksSortOrder.kt
+++ b/app/src/main/java/com/hero/ziggymusic/domain/music/model/MusicTracksSortOrder.kt
@@ -1,0 +1,22 @@
+package com.hero.ziggymusic.domain.music.model
+
+enum class MusicTracksSortOrder {
+    TITLE_ASCENDING,
+    TITLE_DESCENDING,
+    ARTIST_ASCENDING,
+    ARTIST_DESCENDING,
+    DATE_ADDED_ASCENDING,
+    DATE_ADDED_DESCENDING;
+
+    val isTitleOrder: Boolean
+        get() = this == TITLE_ASCENDING || this == TITLE_DESCENDING
+
+    val isArtistOrder: Boolean
+        get() = this == ARTIST_ASCENDING || this == ARTIST_DESCENDING
+
+    val isDateAddedOrder: Boolean
+        get() = this == DATE_ADDED_ASCENDING || this == DATE_ADDED_DESCENDING
+
+    val isDescending: Boolean
+        get() = this == TITLE_DESCENDING || this == ARTIST_DESCENDING || this == DATE_ADDED_DESCENDING
+}

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -51,6 +51,9 @@ import com.hero.ziggymusic.data.local.preferences.LastPlaybackStore
 import com.hero.ziggymusic.presentation.main.player.manager.PlayerController
 import com.hero.ziggymusic.presentation.main.player.manager.PlayerMotionManager
 import com.hero.ziggymusic.presentation.main.player.viewmodel.PlayerViewModel
+import com.hero.ziggymusic.domain.music.model.MusicTracksSortOrder
+import com.hero.ziggymusic.presentation.main.musictracks.viewmodel.MusicTracksViewModel
+import com.hero.ziggymusic.presentation.main.popup.MusicTracksSortMenuPopup
 import com.hero.ziggymusic.presentation.main.setting.AppSettingsFragment
 import com.hero.ziggymusic.presentation.main.setting.WebPageFragment
 import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
@@ -63,6 +66,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
     private lateinit var binding: ActivityMainBinding
     private val vm by viewModels<MainViewModel>()
     private val playerVm by viewModels<PlayerViewModel>()
+    private val musicTracksVm by viewModels<MusicTracksViewModel>()
     private val audioSettingsVm by viewModels<AudioSettingsViewModel>()
 
     @Inject
@@ -138,6 +142,10 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                 is WebPageFragment -> vm.setTitle(MainTitle.WebPage(currentFragment.titleResId))
                 is LicenseNoticesFragment -> vm.setTitle(MainTitle.LicenseNotices)
             }
+        }
+
+        binding.ivSortMusicTracks.setOnClickListener {
+            showMusicTrackSortMenu()
         }
 
         // 현재 메인 탭을 숨기고 설정 화면을 백스택 위에 표시한다.
@@ -360,6 +368,8 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                 currentTitle.observe(this@MainActivity) { mainTitle ->
                     binding.tvMainTitle.text = getString(mainTitle.resId)
                     binding.ivBack.isVisible = mainTitle.showBackButton
+                    binding.ivSortMusicTracks.isVisible = mainTitle.showMusicTrackSortButton
+                    binding.ivSortMusicTracks.isEnabled = mainTitle.showMusicTrackSortButton
                     binding.ivAppSettings.isVisible = mainTitle.showAppSettingsButton
                     binding.ivAppSettings.isEnabled = mainTitle.showAppSettingsButton
                 }
@@ -593,6 +603,20 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             context = this,
             action = MusicService.ACTION_REFRESH_NOTIFICATION
         )
+    }
+
+    private fun showMusicTrackSortMenu() {
+        val selectedSortOrder =
+            musicTracksVm.musicTracksSortOrder.value
+                ?: MusicTracksSortOrder.TITLE_ASCENDING
+
+        MusicTracksSortMenuPopup(
+            anchorView = binding.ivSortMusicTracks,
+            selectedSortOrder = selectedSortOrder,
+            onSortOrderSelected = { sortOrder ->
+                musicTracksVm.setMusicTrackSortOrder(sortOrder)
+            }
+        ).show()
     }
 
     // 하단 탭 이동 시 설정 계열 백스택을 한 번에 제거한다.

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/model/MainTitle.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/model/MainTitle.kt
@@ -7,9 +7,15 @@ sealed class MainTitle(
     @get:StringRes val resId: Int,
     val showBackButton: Boolean = false,
     val showAppSettingsButton: Boolean = true,
+    val showMusicTrackSortButton: Boolean = false,
 ) {
-    object MusicTracks : MainTitle(R.string.title_music_tracks)
+    object MusicTracks : MainTitle(
+        resId = R.string.title_music_tracks,
+        showMusicTrackSortButton = true
+    )
+
     object FavoriteTracks : MainTitle(R.string.title_favorite_tracks)
+
     object AppSettings : MainTitle(
         resId = R.string.title_app_settings,
         showBackButton = true,

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/MusicTracksFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/MusicTracksFragment.kt
@@ -22,7 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -34,6 +34,7 @@ import com.hero.ziggymusic.databinding.FragmentMusicTracksBinding
 import com.hero.ziggymusic.presentation.common.event.EventBus
 import com.hero.ziggymusic.presentation.common.ext.playMusic
 import com.hero.ziggymusic.playback.queue.PlaybackQueueSource
+import com.hero.ziggymusic.domain.music.model.MusicTracksSortOrder
 import com.hero.ziggymusic.presentation.main.popup.MusicTrackOptionMenuPopup
 import com.hero.ziggymusic.presentation.main.musictracks.viewmodel.MusicTrackSearchResult
 import com.hero.ziggymusic.presentation.main.musictracks.viewmodel.MusicTrackListUiState
@@ -47,7 +48,7 @@ class MusicTracksFragment : Fragment() {
     private var _binding: FragmentMusicTracksBinding? = null
     private val binding get() = _binding!!
 
-    private val vm by viewModels<MusicTracksViewModel>()
+    private val vm by activityViewModels<MusicTracksViewModel>()
 
     private lateinit var musicTrackAdapter: MusicTrackAdapter
     private var isRefreshedAfterPermission = false
@@ -60,6 +61,9 @@ class MusicTracksFragment : Fragment() {
     private var lastRecyclerTouchY = 0f
     private var lastSearchContainerTouchY = 0f
     private var searchRequestId = 0L
+    private var lastMusicTracksSortOrder: MusicTracksSortOrder? = null
+    private var pendingMusicTrackScrollPosition: MusicTrackScrollPosition? = null
+    private var scrollToTopAfterSortPending = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -82,6 +86,8 @@ class MusicTracksFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+
+        vm.updateMusicTrackSortForCurrentLanguage()
 
         if (hasAudioPermission()) {
             if (!isRefreshedAfterPermission) {
@@ -281,6 +287,9 @@ class MusicTracksFragment : Fragment() {
 
             binding.rvMusicTracks.isVisible = searchResult.hasOriginalItems || searchResult.items.isNotEmpty()
 
+            // 정렬된 목록이 반영된 뒤 예약된 스크롤을 적용한다.
+            applyMusicTrackScrollAfterSort()
+
             if (searchResult.items.isEmpty()) {
                 showEmptySearchMessageAfterListSettled(
                     requestId = currentRequestId,
@@ -471,6 +480,25 @@ class MusicTracksFragment : Fragment() {
     }
 
     private fun collectUiState() {
+        vm.musicTracksSortOrder.observe(
+            viewLifecycleOwner
+        ) { sortOrder ->
+            val previousSortOrder = lastMusicTracksSortOrder
+
+            // 저장된 정렬 상태의 최초 전달에는 스크롤 정책을 적용하지 않는다.
+            if (previousSortOrder != null && previousSortOrder != sortOrder) {
+                if (sortOrder.isDateAddedOrder) {
+                    scrollToTopAfterSortPending = true
+                    pendingMusicTrackScrollPosition = null
+                } else {
+                    scrollToTopAfterSortPending = false
+                    pendingMusicTrackScrollPosition = captureMusicTrackScrollPosition()
+                }
+            }
+
+            lastMusicTracksSortOrder = sortOrder
+        }
+
         vm.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is MusicTrackListUiState.Idle -> {
@@ -517,6 +545,84 @@ class MusicTracksFragment : Fragment() {
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    private fun applyMusicTrackScrollAfterSort() {
+        if (scrollToTopAfterSortPending) {
+            scrollToTopAfterSortPending = false
+            pendingMusicTrackScrollPosition = null
+
+            scrollMusicTracksToTop()
+            return
+        }
+
+        val scrollPosition = pendingMusicTrackScrollPosition ?: return
+
+        pendingMusicTrackScrollPosition = null
+
+        restoreMusicTrackScrollPosition(scrollPosition)
+    }
+
+    private fun captureMusicTrackScrollPosition(): MusicTrackScrollPosition? {
+        val layoutManager =
+            binding.rvMusicTracks.layoutManager
+                    as? LinearLayoutManager
+                ?: return null
+
+        val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+
+        if (firstVisiblePosition == RecyclerView.NO_POSITION) return null
+
+        val firstVisibleView =
+            layoutManager.findViewByPosition(
+                firstVisiblePosition
+            ) ?: return null
+
+        return MusicTrackScrollPosition(
+            adapterPosition = firstVisiblePosition,
+
+            // 검색창으로 paddingTop이 바뀌어도 같은 화면 위치를 복원하도록 상대 offset을 저장한다.
+            topOffset = firstVisibleView.top - binding.rvMusicTracks.paddingTop
+        )
+    }
+
+    private fun restoreMusicTrackScrollPosition(
+        scrollPosition: MusicTrackScrollPosition,
+    ) {
+        val layoutManager =
+            binding.rvMusicTracks.layoutManager
+                    as? LinearLayoutManager
+                ?: return
+
+        val lastAdapterPosition = musicTrackAdapter.itemCount - 1
+
+        if (lastAdapterPosition < 0) return
+
+        // 목록 갱신 중 항목 수가 바뀌어도 유효한 위치로 보정한다.
+        val availablePosition =
+            scrollPosition.adapterPosition.coerceIn(
+                minimumValue = 0,
+                maximumValue = lastAdapterPosition
+            )
+
+        layoutManager.scrollToPositionWithOffset(
+            availablePosition,
+            scrollPosition.topOffset
+        )
+    }
+
+    private fun scrollMusicTracksToTop() {
+        val layoutManager =
+            binding.rvMusicTracks.layoutManager
+                    as? LinearLayoutManager
+                ?: return
+
+        if (musicTrackAdapter.itemCount == 0) return
+
+        layoutManager.scrollToPositionWithOffset(
+            0,
+            0
+        )
     }
 
     private fun hasAudioPermission(): Boolean {
@@ -597,6 +703,11 @@ class MusicTracksFragment : Fragment() {
             }
         }
     }
+
+    private data class MusicTrackScrollPosition(
+        val adapterPosition: Int,
+        val topOffset: Int,
+    )
 
     companion object {
         private const val SEARCH_ANIMATION_DURATION_MS = 180L

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/viewmodel/MusicTracksViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/viewmodel/MusicTracksViewModel.kt
@@ -21,6 +21,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
+import com.hero.ziggymusic.domain.music.model.MusicTracksSortOrder
+import com.hero.ziggymusic.data.local.preferences.MusicTracksSortStore
+import java.text.Collator
+import java.util.Locale
+import androidx.core.os.ConfigurationCompat
+import java.text.Normalizer
 
 sealed class MusicTrackListUiState {
     object Idle : MusicTrackListUiState()
@@ -38,16 +44,38 @@ data class MusicTrackSearchResult(
 @HiltViewModel
 class MusicTracksViewModel @Inject constructor(
     application: Application,
-    private val musicRepository : MusicRepository
+    private val musicRepository: MusicRepository,
+    private val musicTracksSortStore: MusicTracksSortStore,
 ) : AndroidViewModel(application) {
     private var musicLibrarySyncJob: Job? = null // 음악 목록 동기화 중복 실행을 방지한다.
     private var mediaStoreChangesJob: Job? = null // MediaStore 변경 감지 작업의 중복 실행을 방지한다.
 
-    val favoriteMusicTrackIdList: LiveData<Set<String>> = musicRepository.observeFavoriteTrackIdList().map { trackIdList ->
-        trackIdList.toSet()
-    } // 전체 음악 목록에서 각 음악의 즐겨찾기 여부를 확인하기 위해 즐겨찾기 음악 목록을 중복 없는 ID 집합으로 변환
+    val favoriteMusicTrackIdList: LiveData<Set<String>> =
+        musicRepository.observeFavoriteTrackIdList().map { trackIdList ->
+            trackIdList.toSet()
+        } // 전체 음악 목록에서 각 음악의 즐겨찾기 여부를 확인하기 위해 즐겨찾기 음악 목록을 중복 없는 ID 집합으로 변환
 
     val musicTrackList = musicRepository.observeMusicTracks()
+
+    // 정렬 기준이나 앱 언어가 바뀔 때 다시 정렬할 최신 전체 목록을 보관한다.
+    private var currentMusicTracks: List<MusicTrackEntity> = emptyList()
+
+    private val _musicTracksSortOrder = MutableLiveData(
+        musicTracksSortStore.loadMusicTracksSortOrder()
+    )
+
+    val musicTracksSortOrder: LiveData<MusicTracksSortOrder>
+        get() = _musicTracksSortOrder
+
+    private enum class MusicTrackTextGroup {
+        HANGUL, // 한글
+        LATIN, // 영문 알파벳
+        OTHER, // 기타 (숫자, 일본어, 중국어 등)
+        EMPTY // 제목 또는 아티스트가 비어 있음
+    }
+
+    // 앱 언어가 바뀐 경우에만 다시 정렬하도록 마지막 언어를 기억한다.
+    private var lastMusicTrackSortLocaleTag: String? = null
 
     private val _uiState = MutableLiveData<MusicTrackListUiState>(MusicTrackListUiState.Idle)
     val uiState: LiveData<MusicTrackListUiState>
@@ -95,7 +123,8 @@ class MusicTracksViewModel @Inject constructor(
                 // 사용자에게 먼저 목록을 보여준 뒤 캐시를 저장한다.
                 musicRepository.replaceCachedMusicTracks(trackList)
             }.onFailure {
-                _toastEvent.value = SingleEvent(getApplication<Application>()
+                _toastEvent.value = SingleEvent(
+                    getApplication<Application>()
                         .getString(R.string.load_music_tracks_failed)
                 )
                 _uiState.value = MusicTrackListUiState.Error
@@ -104,14 +133,27 @@ class MusicTracksViewModel @Inject constructor(
     }
 
     private fun updateMusicTrackListUiState(
-        trackList: List<MusicTrackEntity>
+        trackList: List<MusicTrackEntity>,
     ) {
+        currentMusicTracks = trackList
+
         if (trackList.isEmpty()) {
-            val message = getApplication<Application>().getString(R.string.no_music_track_found)
+            val message = getApplication<Application>()
+                .getString(R.string.no_music_track_found)
+
             _uiState.value = MusicTrackListUiState.Empty(message)
-        } else {
-            _uiState.value = MusicTrackListUiState.Content(trackList)
+            return
         }
+
+        val selectedSortOrder =
+            musicTracksSortOrder.value ?: MusicTracksSortOrder.TITLE_ASCENDING
+
+        _uiState.value = MusicTrackListUiState.Content(
+            sortMusicTracks(
+                trackList = trackList,
+                sortOrder = selectedSortOrder
+            )
+        )
     }
 
     @OptIn(FlowPreview::class)
@@ -156,7 +198,7 @@ class MusicTracksViewModel @Inject constructor(
 
     fun setSearchMusicItems(
         musicItems: List<MusicTrackEntity>,
-        emptyStateMessage: String = ""
+        emptyStateMessage: String = "",
     ) {
         hasSearchMusicItems = true
         currentStateMessage = emptyStateMessage
@@ -173,7 +215,10 @@ class MusicTracksViewModel @Inject constructor(
         _searchResult.value = null
     }
 
-    fun searchMusicItems(query: String, musicTracks: List<MusicTrackEntity>): MusicTrackSearchResult {
+    fun searchMusicItems(
+        query: String,
+        musicTracks: List<MusicTrackEntity>,
+    ): MusicTrackSearchResult {
         val keyword = query.trim()
         val filteredItems = if (keyword.isBlank()) {
             musicTracks
@@ -198,13 +243,349 @@ class MusicTracksViewModel @Inject constructor(
         )
     }
 
+    fun setMusicTrackSortOrder(
+        sortOrder: MusicTracksSortOrder,
+    ) {
+        if (_musicTracksSortOrder.value == sortOrder) return
+
+        musicTracksSortStore.saveMusicTracksSortOrder(sortOrder)
+
+        _musicTracksSortOrder.value = sortOrder
+
+        if (currentMusicTracks.isNotEmpty()) {
+            updateMusicTrackListUiState(
+                currentMusicTracks
+            )
+        }
+    }
+
+    private fun sortMusicTracks(
+        trackList: List<MusicTrackEntity>,
+        sortOrder: MusicTracksSortOrder,
+    ): List<MusicTrackEntity> {
+        val appLocale = getCurrentAppLocale()
+        val collator = createMusicTrackCollator(appLocale)
+
+        lastMusicTrackSortLocaleTag = appLocale.toLanguageTag()
+
+        if (sortOrder.isDateAddedOrder) {
+            return sortMusicTracksByDateAdded(
+                trackList = trackList,
+                sortOrder = sortOrder,
+                appLocale = appLocale,
+                collator = collator
+            )
+        }
+
+        return trackList.sortedWith { firstTrack, secondTrack ->
+            val primaryResult = if (sortOrder.isTitleOrder) {
+                compareMusicTrackText(
+                    first = firstTrack.title,
+                    second = secondTrack.title,
+                    descending = sortOrder.isDescending,
+                    appLocale = appLocale,
+                    collator = collator
+                )
+            } else {
+                compareMusicTrackText(
+                    first = firstTrack.artist,
+                    second = secondTrack.artist,
+                    descending = sortOrder.isDescending,
+                    appLocale = appLocale,
+                    collator = collator
+                )
+            }
+
+            if (primaryResult != 0) {
+                primaryResult
+            } else {
+                // 1차 비교값이 같으면 다른 항목과 id로 순서를 일정하게 유지한다.
+                val secondaryResult = if (sortOrder.isTitleOrder) {
+                    compareMusicTrackText(
+                        first = firstTrack.artist,
+                        second = secondTrack.artist,
+                        descending = sortOrder.isDescending,
+                        appLocale = appLocale,
+                        collator = collator
+                    )
+                } else {
+                    compareMusicTrackText(
+                        first = firstTrack.title,
+                        second = secondTrack.title,
+                        descending = sortOrder.isDescending,
+                        appLocale = appLocale,
+                        collator = collator
+                    )
+                }
+
+                if (secondaryResult != 0) {
+                    secondaryResult
+                } else {
+                    firstTrack.id.compareTo(secondTrack.id)
+                }
+            }
+        }
+    }
+
+    private fun sortMusicTracksByDateAdded(
+        trackList: List<MusicTrackEntity>,
+        sortOrder: MusicTracksSortOrder,
+        appLocale: Locale,
+        collator: Collator,
+    ): List<MusicTrackEntity> {
+        return trackList.sortedWith { firstTrack, secondTrack ->
+            val dateResult =
+                compareMusicTrackDateAdded(
+                    first = firstTrack.dateAdded,
+                    second = secondTrack.dateAdded,
+                    descending = sortOrder.isDescending
+                )
+
+            if (dateResult != 0) {
+                dateResult
+            } else {
+                // 같은 날짜는 제목, 아티스트, id 순으로 비교해 순서를 일정하게 유지한다.
+                val titleResult =
+                    compareMusicTrackText(
+                        first = firstTrack.title,
+                        second = secondTrack.title,
+                        descending = false,
+                        appLocale = appLocale,
+                        collator = collator
+                    )
+
+                if (titleResult != 0) {
+                    titleResult
+                } else {
+                    val artistResult =
+                        compareMusicTrackText(
+                            first = firstTrack.artist,
+                            second = secondTrack.artist,
+                            descending = false,
+                            appLocale = appLocale,
+                            collator = collator
+                        )
+
+                    if (artistResult != 0) {
+                        artistResult
+                    } else {
+                        firstTrack.id.compareTo(secondTrack.id)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun compareMusicTrackDateAdded(
+        first: Long,
+        second: Long,
+        descending: Boolean,
+    ): Int {
+        // 날짜를 알 수 없는 항목은 정렬 방향과 관계없이 마지막에 둔다.
+        val firstHasDateAdded = first > 0L
+        val secondHasDateAdded = second > 0L
+
+        if (firstHasDateAdded != secondHasDateAdded) {
+            return if (firstHasDateAdded) {
+                -1
+            } else {
+                1
+            }
+        }
+
+        return if (descending) {
+            second.compareTo(first)
+        } else {
+            first.compareTo(second)
+        }
+    }
+
+    private fun compareMusicTrackText(
+        first: String?,
+        second: String?,
+        descending: Boolean,
+        appLocale: Locale,
+        collator: Collator,
+    ): Int {
+        val firstText = normalizeMusicTrackText(first)
+        val secondText = normalizeMusicTrackText(second)
+
+        val firstGroup = getMusicTrackTextGroup(firstText)
+        val secondGroup = getMusicTrackTextGroup(secondText)
+
+        val firstGroupRank = getMusicTrackTextGroupRank(
+            group = firstGroup,
+            appLocale = appLocale,
+            descending = descending
+        )
+
+        val secondGroupRank = getMusicTrackTextGroupRank(
+            group = secondGroup,
+            appLocale = appLocale,
+            descending = descending
+        )
+
+        val groupResult = firstGroupRank.compareTo(secondGroupRank)
+
+        if (groupResult != 0) {
+            return groupResult
+        }
+
+        val compareResult =
+            collator.compare(firstText, secondText)
+
+        return if (descending) {
+            -compareResult
+        } else {
+            compareResult
+        }
+    }
+
+    fun updateMusicTrackSortForCurrentLanguage() {
+        if (currentMusicTracks.isEmpty()) return
+
+        val currentLocaleTag = getCurrentAppLocale().toLanguageTag()
+
+        if (lastMusicTrackSortLocaleTag == currentLocaleTag) {
+            return
+        }
+
+        updateMusicTrackListUiState(currentMusicTracks)
+    }
+
+    private fun createMusicTrackCollator(
+        locale: Locale,
+    ): Collator {
+        return Collator.getInstance(locale).apply {
+            strength = Collator.PRIMARY
+            decomposition = Collator.CANONICAL_DECOMPOSITION
+        }
+    }
+
+    private fun getCurrentAppLocale(): Locale {
+        val localeList = ConfigurationCompat.getLocales(
+            getApplication<Application>().resources.configuration
+        )
+
+        return if (localeList.isEmpty) {
+            Locale.getDefault()
+        } else {
+            localeList[0] ?: Locale.getDefault()
+        }
+    }
+
+    private fun normalizeMusicTrackText(
+        text: String?,
+    ): String {
+        return Normalizer.normalize(
+            text?.trim().orEmpty(),
+            Normalizer.Form.NFC
+        )
+    }
+
+    private fun getMusicTrackTextGroup(
+        text: String,
+    ): MusicTrackTextGroup {
+        if (text.isBlank()) {
+            return MusicTrackTextGroup.EMPTY
+        }
+
+        // 앞쪽 기호를 건너뛰고 첫 문자나 숫자를 기준으로 그룹을 판별한다.
+        val firstMeaningfulCharacter =
+            text.firstOrNull { character ->
+                Character.isLetterOrDigit(character)
+            } ?: return MusicTrackTextGroup.OTHER
+
+        return when (
+            Character.UnicodeScript.of(
+                firstMeaningfulCharacter.code
+            )
+        ) {
+            Character.UnicodeScript.HANGUL ->
+                MusicTrackTextGroup.HANGUL
+
+            Character.UnicodeScript.LATIN ->
+                MusicTrackTextGroup.LATIN
+
+            else ->
+                MusicTrackTextGroup.OTHER
+        }
+    }
+
+    private fun getMusicTrackTextGroupRank(
+        group: MusicTrackTextGroup,
+        appLocale: Locale,
+        descending: Boolean,
+    ): Int {
+        return when (group) {
+            MusicTrackTextGroup.EMPTY -> 3
+            MusicTrackTextGroup.OTHER -> 2
+
+            MusicTrackTextGroup.HANGUL,
+            MusicTrackTextGroup.LATIN,
+                -> {
+                getHangulAndLatinGroupRank(
+                    group = group,
+                    appLocale = appLocale,
+                    descending = descending
+                )
+            }
+        }
+    }
+
+    private fun getHangulAndLatinGroupRank(
+        group: MusicTrackTextGroup,
+        appLocale: Locale,
+        descending: Boolean,
+    ): Int {
+        // 한국어·영어에서는 앱 언어의 문자 그룹을 우선하고 내림차순에서 순서를 뒤집는다.
+        val hangulFirst = when (appLocale.language) {
+            Locale.KOREAN.language -> {
+                /*
+                 * 한국어:
+                 * 오름차순 = 한글 → 영문
+                 * 내림차순 = 영문 → 한글
+                 */
+                !descending
+            }
+
+            Locale.ENGLISH.language -> {
+                /*
+                 * 영어:
+                 * 오름차순 = 영문 → 한글
+                 * 내림차순 = 한글 → 영문
+                 */
+                descending
+            }
+
+            else -> {
+                /*
+                 * 아직 명시적인 정책이 없는 언어에서는
+                 * 한글과 영문에 동일한 그룹 순위를 주고
+                 * Collator가 순서를 결정하게 한다.
+                 */
+                return 0
+            }
+        }
+
+        return when (group) {
+            MusicTrackTextGroup.HANGUL ->
+                if (hangulFirst) 0 else 1
+
+            MusicTrackTextGroup.LATIN ->
+                if (hangulFirst) 1 else 0
+
+            else -> 2
+        }
+    }
+
     fun addMusicTrackToFavorites(id: String) {
         viewModelScope.launch {
             musicRepository.addMusicTrackToFavorites(id)
         }
     }
 
-    fun isContainedInFavorites(id: String) : Boolean {
+    fun isContainedInFavorites(id: String): Boolean {
         return id in favoriteMusicTrackIdList.value.orEmpty()
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/popup/MusicTracksSortMenuPopup.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/popup/MusicTracksSortMenuPopup.kt
@@ -1,0 +1,192 @@
+package com.hero.ziggymusic.presentation.main.popup
+
+import android.graphics.Color
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.PopupWindow
+import androidx.annotation.StringRes
+import androidx.core.graphics.drawable.toDrawable
+import com.hero.ziggymusic.R
+import com.hero.ziggymusic.databinding.PopupMusicTracksSortMenuBinding
+import com.hero.ziggymusic.domain.music.model.MusicTracksSortOrder
+
+class MusicTracksSortMenuPopup(
+    private val anchorView: View,
+    private val selectedSortOrder: MusicTracksSortOrder,
+    private val onSortOrderSelected: (MusicTracksSortOrder) -> Unit,
+) {
+    fun show() {
+        val binding = PopupMusicTracksSortMenuBinding.inflate(
+            LayoutInflater.from(anchorView.context)
+        )
+
+        val popupWidth =
+            anchorView.resources.getDimensionPixelSize(
+                R.dimen.music_tracks_sort_menu_popup_width
+            )
+
+        val popupWindow = PopupWindow(
+            binding.root,
+            popupWidth,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            true
+        ).apply {
+            isOutsideTouchable = true
+            elevation = anchorView.resources.getDimension(
+                R.dimen.music_option_menu_popup_elevation
+            )
+            setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+        }
+
+        updateSortItemState(
+            layout = binding.layoutTitleSort,
+            checkIcon = binding.ivCheckTitleSort,
+            directionIcon = binding.ivDirectionTitleSort,
+            isSelected = selectedSortOrder.isTitleOrder,
+            labelResId = R.string.sort_title
+        )
+
+        updateSortItemState(
+            layout = binding.layoutArtistSort,
+            checkIcon = binding.ivCheckArtistSort,
+            directionIcon = binding.ivDirectionArtistSort,
+            isSelected = selectedSortOrder.isArtistOrder,
+            labelResId = R.string.sort_artist
+        )
+
+        updateSortItemState(
+            layout = binding.layoutAddedDateSort,
+            checkIcon = binding.ivCheckAddedDateSort,
+            directionIcon = binding.ivDirectionAddedDateSort,
+            isSelected = selectedSortOrder.isDateAddedOrder,
+            labelResId = R.string.sort_added_date
+        )
+
+        binding.layoutTitleSort.setOnClickListener {
+            onSortOrderSelected(
+                getNextTitleSortOrder()
+            )
+            popupWindow.dismiss()
+        }
+
+        binding.layoutArtistSort.setOnClickListener {
+            onSortOrderSelected(
+                getNextArtistSortOrder()
+            )
+            popupWindow.dismiss()
+        }
+
+        binding.layoutAddedDateSort.setOnClickListener {
+            onSortOrderSelected(
+                getNextDateAddedSortOrder()
+            )
+            popupWindow.dismiss()
+        }
+
+        popupWindow.showAsDropDown(
+            anchorView,
+            0,
+            0,
+            Gravity.END
+        )
+    }
+
+    private fun updateSortItemState(
+        layout: View,
+        checkIcon: ImageView,
+        directionIcon: ImageView,
+        isSelected: Boolean,
+        @StringRes labelResId: Int,
+    ) {
+        val visibility =
+            if (isSelected) View.VISIBLE else View.INVISIBLE
+
+        checkIcon.visibility = visibility
+        directionIcon.visibility = visibility
+        layout.isSelected = isSelected
+
+        if (!isSelected) {
+            layout.contentDescription =
+                anchorView.context.getString(labelResId)
+            return
+        }
+
+        val directionIconResId =
+            if (selectedSortOrder.isDescending) {
+                R.drawable.ic_sort_descending
+            } else {
+                R.drawable.ic_sort_ascending
+            }
+
+        val directionTextResId =
+            if (selectedSortOrder.isDescending) {
+                R.string.sort_descending
+            } else {
+                R.string.sort_ascending
+            }
+
+        directionIcon.setImageResource(directionIconResId)
+
+        layout.contentDescription =
+            anchorView.context.getString(
+                R.string.sort_item_selected_description,
+                anchorView.context.getString(labelResId),
+                anchorView.context.getString(directionTextResId)
+            )
+    }
+
+    // 같은 기준을 다시 선택하면 방향을 전환하고, 새 기준은 기본 방향으로 시작한다.
+    private fun getNextTitleSortOrder(): MusicTracksSortOrder {
+        return when (selectedSortOrder) {
+            MusicTracksSortOrder.TITLE_ASCENDING ->
+                MusicTracksSortOrder.TITLE_DESCENDING
+
+            MusicTracksSortOrder.TITLE_DESCENDING ->
+                MusicTracksSortOrder.TITLE_ASCENDING
+
+            MusicTracksSortOrder.ARTIST_ASCENDING,
+            MusicTracksSortOrder.ARTIST_DESCENDING,
+            MusicTracksSortOrder.DATE_ADDED_ASCENDING,
+            MusicTracksSortOrder.DATE_ADDED_DESCENDING,
+                ->
+                MusicTracksSortOrder.TITLE_ASCENDING
+        }
+    }
+
+    private fun getNextArtistSortOrder(): MusicTracksSortOrder {
+        return when (selectedSortOrder) {
+            MusicTracksSortOrder.ARTIST_ASCENDING ->
+                MusicTracksSortOrder.ARTIST_DESCENDING
+
+            MusicTracksSortOrder.ARTIST_DESCENDING ->
+                MusicTracksSortOrder.ARTIST_ASCENDING
+
+            MusicTracksSortOrder.TITLE_ASCENDING,
+            MusicTracksSortOrder.TITLE_DESCENDING,
+            MusicTracksSortOrder.DATE_ADDED_ASCENDING,
+            MusicTracksSortOrder.DATE_ADDED_DESCENDING,
+                ->
+                MusicTracksSortOrder.ARTIST_ASCENDING
+        }
+    }
+
+    private fun getNextDateAddedSortOrder(): MusicTracksSortOrder {
+        return when (selectedSortOrder) {
+            MusicTracksSortOrder.DATE_ADDED_DESCENDING ->
+                MusicTracksSortOrder.DATE_ADDED_ASCENDING
+
+            MusicTracksSortOrder.DATE_ADDED_ASCENDING ->
+                MusicTracksSortOrder.DATE_ADDED_DESCENDING
+
+            MusicTracksSortOrder.TITLE_ASCENDING,
+            MusicTracksSortOrder.TITLE_DESCENDING,
+            MusicTracksSortOrder.ARTIST_ASCENDING,
+            MusicTracksSortOrder.ARTIST_DESCENDING,
+                ->
+                MusicTracksSortOrder.DATE_ADDED_DESCENDING
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/drawable/ic_sort_ascending.xml
+++ b/app/src/main/res/drawable/ic_sort_ascending.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- 길이가 다른 정렬선 -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="
+            M3,6
+            L12,6
+
+            M3,12
+            L9.5,12
+
+            M3,18
+            L7,18"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.3" />
+
+    <!-- 오름차순 화살표 -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="
+            M18,19
+            L18,6
+
+            M14.5,9.5
+            L18,6
+            L21.5,9.5"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.3" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_sort_descending.xml
+++ b/app/src/main/res/drawable/ic_sort_descending.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- 길이가 다른 정렬선 -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="
+            M3,6
+            L12,6
+
+            M3,12
+            L9.5,12
+
+            M3,18
+            L7,18"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.3" />
+
+    <!-- 내림차순 화살표 -->
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="
+            M18,5
+            L18,18
+
+            M14.5,14.5
+            L18,18
+            L21.5,14.5"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.3" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_sort_music_tracks.xml
+++ b/app/src/main/res/drawable/ic_sort_music_tracks.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="
+            M3.5,5
+            L20.5,5
+
+            M3.5,12
+            L15.5,12
+
+            M3.5,19
+            L10.5,19"
+        android:strokeColor="@android:color/white"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.7" />
+
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,8 +26,8 @@
                 android:layout_height="@dimen/toolbar_icon_touch_size"
                 android:layout_marginStart="@dimen/space_sm"
                 android:padding="@dimen/toolbar_icon_padding"
-                android:src="@drawable/ic_left_arrow"
                 android:scaleType="fitCenter"
+                android:src="@drawable/ic_left_arrow"
                 android:visibility="invisible"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -45,13 +45,30 @@
                 tools:text="음악 목록" />
 
             <ImageView
+                android:id="@+id/ivSortMusicTracks"
+                android:layout_width="@dimen/toolbar_icon_touch_size"
+                android:layout_height="@dimen/toolbar_icon_touch_size"
+                android:layout_marginEnd="@dimen/space_xxs"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/music_track_sort"
+                android:focusable="true"
+                android:padding="@dimen/toolbar_music_tracks_sort_icon_padding"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_sort_music_tracks"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/ivAppSettings"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
                 android:id="@+id/ivAppSettings"
                 android:layout_width="@dimen/toolbar_icon_touch_size"
                 android:layout_height="@dimen/toolbar_icon_touch_size"
                 android:layout_marginEnd="@dimen/space_sm"
                 android:padding="@dimen/toolbar_icon_padding"
-                android:src="@drawable/ic_app_settings"
                 android:scaleType="fitCenter"
+                android:src="@drawable/ic_app_settings"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/popup_music_tracks_sort_menu.xml
+++ b/app/src/main/res/layout/popup_music_tracks_sort_menu.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="@dimen/music_tracks_sort_menu_popup_width"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_popup_music_option_menu"
+    android:orientation="vertical"
+    android:paddingVertical="@dimen/music_option_menu_popup_vertical_padding">
+
+    <!-- 제목 정렬 -->
+    <LinearLayout
+        android:id="@+id/layoutTitleSort"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/music_tracks_sort_menu_item_height"
+        android:background="?selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/music_tracks_sort_menu_horizontal_padding"
+        android:paddingEnd="@dimen/music_tracks_sort_menu_horizontal_padding">
+
+        <ImageView
+            android:id="@+id/ivCheckTitleSort"
+            android:layout_width="@dimen/icon_sm"
+            android:layout_height="@dimen/icon_sm"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_text_margin_start"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/sort_title"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption" />
+
+        <ImageView
+            android:id="@+id/ivDirectionTitleSort"
+            android:layout_width="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_height="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_direction_icon_margin_start"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_sort_ascending"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/music_tracks_sort_menu_divider_margin"
+        android:layout_marginEnd="@dimen/music_tracks_sort_menu_divider_margin"
+        android:background="@color/music_option_menu_popup_divider" />
+
+    <!-- 아티스트 정렬 -->
+    <LinearLayout
+        android:id="@+id/layoutArtistSort"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/music_tracks_sort_menu_item_height"
+        android:background="?selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/music_tracks_sort_menu_horizontal_padding"
+        android:paddingEnd="@dimen/music_tracks_sort_menu_horizontal_padding">
+
+        <ImageView
+            android:id="@+id/ivCheckArtistSort"
+            android:layout_width="@dimen/icon_sm"
+            android:layout_height="@dimen/icon_sm"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_text_margin_start"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/sort_artist"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption" />
+
+        <ImageView
+            android:id="@+id/ivDirectionArtistSort"
+            android:layout_width="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_height="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_direction_icon_margin_start"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_sort_ascending"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginStart="@dimen/music_tracks_sort_menu_divider_margin"
+        android:layout_marginEnd="@dimen/music_tracks_sort_menu_divider_margin"
+        android:background="@color/music_option_menu_popup_divider" />
+
+    <!-- 추가된 날짜  정렬 -->
+    <LinearLayout
+        android:id="@+id/layoutAddedDateSort"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/music_tracks_sort_menu_item_height"
+        android:background="?selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/music_tracks_sort_menu_horizontal_padding"
+        android:paddingEnd="@dimen/music_tracks_sort_menu_horizontal_padding">
+
+        <ImageView
+            android:id="@+id/ivCheckAddedDateSort"
+            android:layout_width="@dimen/icon_sm"
+            android:layout_height="@dimen/icon_sm"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_text_margin_start"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/sort_added_date"
+            android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption" />
+
+        <ImageView
+            android:id="@+id/ivDirectionAddedDateSort"
+            android:layout_width="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_height="@dimen/music_tracks_sort_menu_direction_icon_size"
+            android:layout_marginStart="@dimen/music_tracks_sort_menu_direction_icon_margin_start"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_sort_ascending"
+            android:visibility="invisible"
+            app:tint="@color/white" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-sw320dp/dimens.xml
+++ b/app/src/main/res/values-sw320dp/dimens.xml
@@ -108,6 +108,16 @@
     <dimen name="seekbar_volume">231dp</dimen>
     <dimen name="layout_volume_padding">46dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">13dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">136dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">50dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">10dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">8dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">18dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">10dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">24dp</dimen>

--- a/app/src/main/res/values-sw360dp/dimens.xml
+++ b/app/src/main/res/values-sw360dp/dimens.xml
@@ -108,6 +108,16 @@
     <dimen name="seekbar_volume">250dp</dimen>
     <dimen name="layout_volume_padding">50dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">13dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">144dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">52dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">8dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">20dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">12dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">28dp</dimen>

--- a/app/src/main/res/values-sw400dp/dimens.xml
+++ b/app/src/main/res/values-sw400dp/dimens.xml
@@ -108,6 +108,16 @@
     <dimen name="seekbar_volume">270dp</dimen>
     <dimen name="layout_volume_padding">56dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">13dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">152dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">54dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">8dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">20dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">12dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">32dp</dimen>

--- a/app/src/main/res/values-sw480dp/dimens.xml
+++ b/app/src/main/res/values-sw480dp/dimens.xml
@@ -108,6 +108,16 @@
     <dimen name="seekbar_volume">300dp</dimen>
     <dimen name="layout_volume_padding">60dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">14dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">160dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">56dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">14dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">10dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">22dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">14dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">38dp</dimen>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -108,6 +108,17 @@
     <dimen name="seekbar_volume">325dp</dimen>
     <dimen name="layout_volume_padding">66dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">14dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">216dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">60dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">16dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">24dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_margin_start">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">16dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">48dp</dimen>

--- a/app/src/main/res/values-sw720dp/dimens.xml
+++ b/app/src/main/res/values-sw720dp/dimens.xml
@@ -108,6 +108,17 @@
     <dimen name="seekbar_volume">350dp</dimen>
     <dimen name="layout_volume_padding">70dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">15dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">232dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">62dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">18dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">14dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">26dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_margin_start">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">18dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">48dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -110,6 +110,17 @@
     <dimen name="seekbar_volume">250dp</dimen>
     <dimen name="layout_volume_padding">50dp</dimen>
 
+    <!-- Music tracks sort popup -->
+
+    <dimen name="toolbar_music_tracks_sort_icon_padding">13dp</dimen>
+    <dimen name="music_tracks_sort_menu_popup_width">144dp</dimen>
+    <dimen name="music_tracks_sort_menu_item_height">52dp</dimen>
+    <dimen name="music_tracks_sort_menu_horizontal_padding">12dp</dimen>
+    <dimen name="music_tracks_sort_menu_text_margin_start">8dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_size">20dp</dimen>
+    <dimen name="music_tracks_sort_menu_direction_icon_margin_start">0dp</dimen>
+    <dimen name="music_tracks_sort_menu_divider_margin">12dp</dimen>
+
     <!-- App Settings -->
 
     <dimen name="app_settings_content_horizontal_inset">28dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,15 @@
     <string name="music_track_search_no_result">검색 결과가 없습니다.</string>
     <string name="music_tracks_load_failed">음원 목록 불러오기 실패</string>
 
+    <!-- Music tracks sort -->
+    <string name="music_track_sort">음원 정렬</string>
+    <string name="sort_title">제목</string>
+    <string name="sort_artist">아티스트</string>
+    <string name="sort_added_date">추가된 날짜</string>
+    <string name="sort_ascending">오름차순</string>
+    <string name="sort_descending">내림차순</string>
+    <string name="sort_item_selected_description">%1$s, %2$s, 선택됨</string>
+
     <!-- App settings -->
     <string name="settings_section_sound">사운드</string>
     <string name="settings_audio_title">음향 설정</string>


### PR DESCRIPTION
# PR 내용
1. 음악 트랙 목록 정렬 기능 추가
- 음악 트랙 목록 화면 툴바에 정렬 버튼과 전용 팝업 메뉴를 추가
- 제목, 아티스트, 추가된 날짜 기준의 오름차순·내림차순 정렬 기능 구현
- 선택된 항목에 체크 표시와 현재 정렬 방향 아이콘을 표시

2. Locale 기반 텍스트 정렬 적용
- 앱 언어의 Collator를 사용해 제목과 아티스트를 정렬
- 한국어와 영어 환경에 따라 한글·영문 그룹의 우선순위를 적용
- 동일한 값은 보조 항목과 음원 id를 비교해 정렬 순서를 일정하게 유지

3. 추가된 날짜 정렬 지원
- MediaStore의 DATE_ADDED 값을 음원 Entity에 저장하도록 데이터 조회를 보완
- 날짜가 같은 음원은 제목, 아티스트, id 순으로 정렬
- 추가된 날짜를 알 수 없는 음원은 정렬 방향과 관계없이 마지막에 표시

4. 정렬 상태와 스크롤 정책 적용
- 최초 실행은 제목 오름차순을 사용하고 이후에는 마지막 정렬 상태를 기억
- 제목·아티스트 정렬은 현재 스크롤 위치를 유지
- 추가된 날짜 정렬은 목록 최상단으로 이동.

5. 화면 크기별 정렬 UI 적용
- 모바일과 태블릿 등 기기별 해상도에 맞춰 팝업 너비, 항목 높이, 여백과 아이콘 크기를 조정
- 선택 상태와 정렬 방향을 접근성 설명에 포함

6. 즐겨찾기 목록 정렬 순서 수정
- 즐겨찾기에 추가한 음악 트랙 목록 정렬 정책을 추가한 날짜를 기준으로 기본 오름차순 정렬로 변경
- 여러 음원이 같은 밀리초에 추가되는 경우는 드물지만 보조 정렬을 두어 쿼리를 실행할 때마다 순서가 달라지는 것을 방지