### PR TITLE
[ Fix ] Custom EQ 기본값 및 복원 안정성 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/audio/repository/AudioSettingsRepositoryImpl.kt
@@ -62,31 +62,47 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         updateStateFromStorage()
     }
 
-    // 프리셋 선택은 EQ 사용 의도가 명확하므로 EQ를 자동으로 켠다.
+    // 선택한 프리셋을 현재 기기 지원 범위로 보정해 저장하고 적용한다.
     override fun setEqualizerPreset(presetPosition: Int) {
-        val normalizedPresetPosition = presetPosition.coerceAtLeast(
-            AudioSettingsUiState.CUSTOM_PRESET_POSITION,
-        )
+        val normalizedPresetPosition = normalizePresetPosition(presetPosition)
 
-        // 어떤 화면에서 프리셋을 선택하든 최근 프리셋 목록을 같은 기준으로 갱신한다.
+        if (
+            normalizedPresetPosition ==
+            AudioSettingsUiState.CUSTOM_PRESET_POSITION
+        ) {
+            setCustomEqualizerPreset()
+            return
+        }
+
         val recentPresetPositions = buildRecentPresetPositions(normalizedPresetPosition)
 
         prefs.edit {
             putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
-            putInt(AudioSettingKeys.KEY_PRESET, normalizedPresetPosition)
-
-            // Custom은 고정 슬롯으로 처리하므로 일반 EQ 프리셋을 선택했을 때만 최근 목록을 저장한다.
-            if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
-                putString(
-                    AudioSettingKeys.KEY_RECENT_PRESET_POSITIONS,
-                    serializeRecentPresetPositions(recentPresetPositions),
-                )
-            }
+            putInt(
+                AudioSettingKeys.KEY_PRESET,
+                normalizedPresetPosition,
+            )
+            putString(
+                AudioSettingKeys.KEY_RECENT_PRESET_POSITIONS,
+                serializeRecentPresetPositions(recentPresetPositions),
+            )
         }
 
-        if (normalizedPresetPosition > AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
-            AudioEffectManager.useEqualizerPreset(normalizedPresetPosition - SETTINGS_PRESET_OFFSET)
+        val wasApplied = AudioEffectManager.useEqualizerPreset(
+            normalizedPresetPosition - SETTINGS_PRESET_OFFSET,
+        )
+
+        if (wasApplied) {
             applyCurrentEqualizerBandsToDsp()
+        } else {
+            // 프리셋 적용에 실패하면 유효한 Custom 값으로 안전하게 전환한다.
+            prefs.edit {
+                putInt(
+                    AudioSettingKeys.KEY_PRESET,
+                    AudioSettingsUiState.CUSTOM_PRESET_POSITION,
+                )
+            }
+            applySavedEqualizerBands()
         }
 
         AudioEffectManager.setEnabledFromPrefs(prefs)
@@ -106,19 +122,152 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         updateStateFromStorage()
     }
 
-    // 저장된 EQ 밴드 progress를 실제 Equalizer와 DSP EQ 값으로 복원한다.
+    // 저장 또는 요청된 프리셋 위치를 현재 기기가 지원하는 범위로 보정한다.
+    private fun normalizePresetPosition(
+        presetPosition: Int,
+    ): Int {
+        val candidate = presetPosition.coerceAtLeast(
+            AudioSettingsUiState.CUSTOM_PRESET_POSITION,
+        )
+
+        // Equalizer가 아직 생성되지 않았다면 기기 지원 개수를 알 수 없으므로
+        // 음수가 아닌 값으로만 보정한다.
+        if (AudioEffectManager.equalizer == null) return candidate
+
+        val numberOfPresets =
+            AudioEffectManager.getNumberOfPresets().coerceAtLeast(0)
+
+        if (numberOfPresets == 0) {
+            return AudioSettingsUiState.CUSTOM_PRESET_POSITION
+        }
+
+        // Settings position은 Custom=0,
+        // Android preset index 0은 Settings position 1이다.
+        return if (candidate in
+            AudioSettingsUiState.CUSTOM_PRESET_POSITION..numberOfPresets
+        ) {
+            candidate
+        } else {
+            AudioSettingsUiState.DEFAULT_PRESET_POSITION.coerceAtMost(
+                numberOfPresets,
+            )
+        }
+    }
+
+    // Android Equalizer의 0 mB를 SeekBar progress로 변환한다.
+    private fun getNeutralBandProgress(
+        minBandLevel: Int,
+        maxBandProgress: Int,
+    ): Int {
+        // native band level = progress + minBandLevel이므로,
+        // native 0 mB에 해당하는 progress는 -minBandLevel이다.
+        return (-minBandLevel).coerceIn(0, maxBandProgress)
+    }
+
+    // 저장된 Custom EQ가 현재 기기의 밴드 수와 레벨 범위에 맞는지 확인한다.
+    private fun isCustomEqStorageCompatible(
+        numberOfBands: Int,
+        minBandLevel: Int,
+        maxBandLevel: Int,
+    ): Boolean {
+        return prefs.getInt(AudioSettingKeys.KEY_CUSTOM_EQ_BAND_COUNT, -1) == numberOfBands &&
+                prefs.getInt(AudioSettingKeys.KEY_CUSTOM_EQ_MIN_LEVEL, Int.MIN_VALUE) == minBandLevel &&
+                prefs.getInt(AudioSettingKeys.KEY_CUSTOM_EQ_MAX_LEVEL, Int.MAX_VALUE) == maxBandLevel
+    }
+
+    // 현재 EQ 밴드 값을 읽고, 읽지 못한 밴드는 저장된 Custom 값으로 보완한다.
+    private fun loadCustomEqualizerBandProgresses(
+        numberOfBands: Int,
+        minBandLevel: Int,
+        maxBandLevel: Int,
+    ): List<Int> {
+        val maxBandProgress = maxBandLevel - minBandLevel
+        val neutralProgress = getNeutralBandProgress(
+            minBandLevel = minBandLevel,
+            maxBandProgress = maxBandProgress,
+        )
+
+        val isCompatible = isCustomEqStorageCompatible(
+            numberOfBands = numberOfBands,
+            minBandLevel = minBandLevel,
+            maxBandLevel = maxBandLevel,
+        )
+
+        return (0 until numberOfBands).map { bandIndex ->
+            if (isCompatible) {
+                prefs.getInt(
+                    bandIndex.toString(),
+                    neutralProgress,
+                ).coerceIn(0, maxBandProgress)
+            } else {
+                neutralProgress
+            }
+        }
+    }
+
+    // Custom 밴드 값과 현재 기기의 EQ 구성 정보를 함께 저장한다.
+    private fun saveCustomEqualizerBandProgresses(
+        progresses: List<Int>,
+        numberOfBands: Int,
+        minBandLevel: Int,
+        maxBandLevel: Int,
+    ) {
+        val maxBandProgress = maxBandLevel - minBandLevel
+
+        prefs.edit {
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_BAND_COUNT, numberOfBands)
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_MIN_LEVEL, minBandLevel)
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_MAX_LEVEL, maxBandLevel)
+
+            progresses.forEachIndexed { bandIndex, progress ->
+                putInt(
+                    bandIndex.toString(),
+                    progress.coerceIn(0, maxBandProgress),
+                )
+            }
+        }
+    }
+
+    // 현재 기기와 호환되는 Custom 밴드 값을 실제 Equalizer에 복원한다.
     private fun applySavedEqualizerBands() {
         val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return
-        val minBandLevel = bandLevelRange[0].toInt() // 실제 Equalizer가 받을 수 있는 최소 밴드 레벨
-        val maxBandLevel = bandLevelRange[1].toInt() // 실제 Equalizer가 받을 수 있는 최대 밴드 레벨
-        val maxBandProgress = maxBandLevel - minBandLevel // SeekBar가 가질 수 있는 최대 progress
+        if (bandLevelRange.size < 2) return
+
+        val minBandLevel = bandLevelRange[0].toInt()
+        val maxBandLevel = bandLevelRange[1].toInt()
+        val maxBandProgress = maxBandLevel - minBandLevel
         val numberOfBands = AudioEffectManager.getNumberOfBands()
 
-        for (bandIndex in 0 until numberOfBands) {
-            val savedProgress = prefs.getInt(bandIndex.toString(), 0)
-            val clampedProgress = savedProgress.coerceIn(0, maxBandProgress)
-            val nativeLevel = (clampedProgress + minBandLevel).toShort()
-            val gainDb = mapEqProgressToDb(clampedProgress, maxBandProgress)
+        if (numberOfBands <= 0 || maxBandProgress < 0) return
+
+        val wasCompatible = isCustomEqStorageCompatible(
+            numberOfBands = numberOfBands,
+            minBandLevel = minBandLevel,
+            maxBandLevel = maxBandLevel,
+        )
+
+        val savedProgresses = loadCustomEqualizerBandProgresses(
+            numberOfBands = numberOfBands,
+            minBandLevel = minBandLevel,
+            maxBandLevel = maxBandLevel,
+        )
+
+        // 최초 선택 또는 기기 EQ 구성이 달라진 경우 중립값으로 저장 형식을 초기화한다.
+        if (!wasCompatible) {
+            saveCustomEqualizerBandProgresses(
+                progresses = savedProgresses,
+                numberOfBands = numberOfBands,
+                minBandLevel = minBandLevel,
+                maxBandLevel = maxBandLevel,
+            )
+        }
+
+        savedProgresses.forEachIndexed { bandIndex, progress ->
+            val nativeLevel = (progress + minBandLevel).toShort()
+            val gainDb = mapEqProgressToDb(
+                progress = progress,
+                max = maxBandProgress,
+            )
 
             AudioEffectManager.applyEqualizerBandLevel(
                 bandIndex = bandIndex,
@@ -135,7 +284,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         return (normalized * 24.0f) - 12.0f
     }
 
-    // 사용자가 EQ 밴드를 직접 조정하면 현재 프리셋을 Custom으로 전환하고 전체 밴드 값을 저장/적용한다.
+    // 사용자가 밴드를 조절하면 현재 EQ 전체 값을 Custom으로 저장하고 즉시 적용한다.
     override fun updateEqualizerBandFromUser(
         bandIndex: Int,
         progress: Int,
@@ -160,11 +309,20 @@ class AudioSettingsRepositoryImpl @Inject constructor(
 
         prefs.edit {
             putBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, true)
-            putInt(AudioSettingKeys.KEY_PRESET, AudioSettingsUiState.CUSTOM_PRESET_POSITION)
+            putInt(
+                AudioSettingKeys.KEY_PRESET,
+                AudioSettingsUiState.CUSTOM_PRESET_POSITION,
+            )
 
-            // Custom 복원에 사용할 전체 EQ 밴드 progress를 SharedPreferences에 저장한다.
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_BAND_COUNT, numberOfBands)
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_MIN_LEVEL, minBandLevel)
+            putInt(AudioSettingKeys.KEY_CUSTOM_EQ_MAX_LEVEL, maxBandLevel)
+
             customBandProgresses.forEachIndexed { index, bandProgress ->
-                putInt(index.toString(), bandProgress)
+                putInt(
+                    index.toString(),
+                    bandProgress.coerceIn(0, maxBandProgress),
+                )
             }
         }
 
@@ -193,12 +351,26 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         maxBandProgress: Int,
     ): List<Int> {
         val numberOfBands = AudioEffectManager.getNumberOfBands()
+        val maxBandLevel = minBandLevel + maxBandProgress
+
+        val fallbackProgresses = loadCustomEqualizerBandProgresses(
+            numberOfBands = numberOfBands,
+            minBandLevel = minBandLevel,
+            maxBandLevel = maxBandLevel,
+        )
 
         return (0 until numberOfBands).map { bandIndex ->
-            val nativeBandLevel = AudioEffectManager.getBandLevel(bandIndex)?.toInt()
-                ?: (prefs.getInt(bandIndex.toString(), 0) + minBandLevel)
+            val fallbackNativeLevel =
+                fallbackProgresses[bandIndex] + minBandLevel
 
-            (nativeBandLevel - minBandLevel).coerceIn(0, maxBandProgress)
+            val nativeBandLevel =
+                AudioEffectManager.getBandLevel(bandIndex)?.toInt()
+                    ?: fallbackNativeLevel
+
+            (nativeBandLevel - minBandLevel).coerceIn(
+                0,
+                maxBandProgress,
+            )
         }
     }
 
@@ -257,12 +429,25 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         _settingsState.value = loadAudioSettingsState()
     }
 
-    // SharedPreferences에 저장된 값을 UI 상태 모델로 변환
+    // 저장된 음향 설정을 현재 기기에서 유효한 UI 상태로 변환한다.
     private fun loadAudioSettingsState(): AudioSettingsUiState {
-        val currentPresetPosition = prefs.getInt(
+        val savedPresetPosition = prefs.getInt(
             AudioSettingKeys.KEY_PRESET,
             AudioSettingsUiState.DEFAULT_PRESET_POSITION,
         )
+
+        val currentPresetPosition =
+            normalizePresetPosition(savedPresetPosition)
+
+        // 지원하지 않는 저장값은 보정된 프리셋 위치로 교체한다.
+        if (savedPresetPosition != currentPresetPosition) {
+            prefs.edit {
+                putInt(
+                    AudioSettingKeys.KEY_PRESET,
+                    currentPresetPosition,
+                )
+            }
+        }
 
         return AudioSettingsUiState(
             isEqualizerEnabled = prefs.getBoolean(AudioSettingKeys.KEY_EQUALIZER_ENABLED, false),
@@ -288,20 +473,33 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         )
     }
 
+    // 현재 프리셋에 맞는 밴드 progress를 UI 표시용으로 구성한다.
     private fun loadEqualizerBandProgresses(currentPresetPosition: Int): List<Int> {
         val bandLevelRange = AudioEffectManager.getBandLevelRange() ?: return emptyList()
+        if (bandLevelRange.size < 2) return emptyList()
+
         val minBandLevel = bandLevelRange[0].toInt()
-        val maxBandProgress = bandLevelRange[1].toInt() - minBandLevel
+        val maxBandLevel = bandLevelRange[1].toInt()
+        val maxBandProgress = maxBandLevel - minBandLevel
         val numberOfBands = AudioEffectManager.getNumberOfBands()
 
+        if (numberOfBands <= 0 || maxBandProgress < 0) return emptyList()
+
         return if (currentPresetPosition == AudioSettingsUiState.CUSTOM_PRESET_POSITION) {
-            (0 until numberOfBands).map { bandIndex ->
-                prefs.getInt(bandIndex.toString(), 0).coerceIn(0, maxBandProgress)
-            }
+            loadCustomEqualizerBandProgresses(
+                numberOfBands = numberOfBands,
+                minBandLevel = minBandLevel,
+                maxBandLevel = maxBandLevel,
+            )
         } else {
             (0 until numberOfBands).map { bandIndex ->
-                val nativeBandLevel = AudioEffectManager.getBandLevel(bandIndex)?.toInt() ?: 0
-                (nativeBandLevel - minBandLevel).coerceIn(0, maxBandProgress)
+                val nativeBandLevel =
+                    AudioEffectManager.getBandLevel(bandIndex)?.toInt() ?: 0
+
+                (nativeBandLevel - minBandLevel).coerceIn(
+                    0,
+                    maxBandProgress,
+                )
             }
         }
     }
@@ -348,7 +546,7 @@ class AudioSettingsRepositoryImpl @Inject constructor(
         return recentPresetPositions.take(RECENT_NON_CUSTOM_PRESET_COUNT)
     }
 
-    // 저장된 최근 프리셋 목록을 읽고, 값이 없거나 부족하면 기본 프리셋으로 보충한다.
+    // 저장된 최근 프리셋 중 현재 기기가 지원하는 항목만 반환한다.
     private fun loadRecentPresetPositions(): List<Int> {
         val savedPresetPositions = prefs.getString(
             AudioSettingKeys.KEY_RECENT_PRESET_POSITIONS,
@@ -358,8 +556,23 @@ class AudioSettingsRepositoryImpl @Inject constructor(
             ?.mapNotNull { it.toIntOrNull() }
             .orEmpty()
 
-        return (savedPresetPositions + AudioSettingsUiState.DEFAULT_RECENT_PRESET_POSITIONS)
-            .filter { it > AudioSettingsUiState.CUSTOM_PRESET_POSITION }
+        val maxSupportedPresetPosition =
+            if (AudioEffectManager.equalizer != null) {
+                AudioEffectManager.getNumberOfPresets()
+                    .coerceAtLeast(0)
+            } else {
+                Int.MAX_VALUE
+            }
+
+        return (
+                savedPresetPositions +
+                        AudioSettingsUiState.DEFAULT_RECENT_PRESET_POSITIONS
+                )
+            .filter { presetPosition ->
+                presetPosition >
+                        AudioSettingsUiState.CUSTOM_PRESET_POSITION &&
+                        presetPosition <= maxSupportedPresetPosition
+            }
             .distinct()
             .take(RECENT_NON_CUSTOM_PRESET_COUNT)
     }

--- a/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
@@ -4,6 +4,12 @@ object AudioSettingKeys {
     const val KEY_EQUALIZER_ENABLED = "EQUALIZER_ENABLED"
     const val KEY_PRESET = "PRESET"
     const val KEY_RECENT_PRESET_POSITIONS = "RECENT_PRESET_POSITIONS" // 바텀시트 최근 프리셋 버튼에 노출할 일반 EQ 프리셋 position 목록
+
+    // Custom EQ 저장값과 현재 기기의 밴드 구성이 호환되는지 확인하기 위한 정보
+    const val KEY_CUSTOM_EQ_BAND_COUNT = "CUSTOM_EQ_BAND_COUNT"
+    const val KEY_CUSTOM_EQ_MIN_LEVEL = "CUSTOM_EQ_MIN_LEVEL"
+    const val KEY_CUSTOM_EQ_MAX_LEVEL = "CUSTOM_EQ_MAX_LEVEL"
+
     const val KEY_BASS = "BASS"
     const val KEY_VIRTUALIZER = "VIRTUALIZER"
     const val KEY_REVERB = "REVERB"

--- a/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
+++ b/app/src/main/java/com/hero/ziggymusic/data/local/preferences/AudioSettingKeys.kt
@@ -14,8 +14,6 @@ object AudioSettingKeys {
     const val KEY_VIRTUALIZER = "VIRTUALIZER"
     const val KEY_REVERB = "REVERB"
     const val KEY_LOUDNESS_NORMALIZER_ENABLED = "LOUDNESS_NORMALIZER_ENABLED"
-    const val KEY_SPATIAL_ENABLED = "SPATIAL_ENABLED"
-    const val KEY_HEAD_TRACKING_ENABLED = "HEAD_TRACKING_ENABLED"
 
     const val PREF_AUDIO_SETTINGS = "audio_settings"
 }

--- a/app/src/main/java/com/hero/ziggymusic/playback/manager/AudioEffectManager.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/manager/AudioEffectManager.kt
@@ -95,8 +95,21 @@ object AudioEffectManager {
         equalizer?.setBandLevel(bandIndex.toShort(), level)
     }
 
-    fun useEqualizerPreset(presetIndex: Int) {
-        equalizer?.usePreset(presetIndex.toShort())
+    // 프리셋 인덱스를 검증한 뒤 적용하고 성공 여부를 반환한다.
+    fun useEqualizerPreset(presetIndex: Int): Boolean {
+        val effect = equalizer ?: return false
+
+        val numberOfPresets = runCatching {
+            effect.numberOfPresets.toInt()
+        }.getOrDefault(0)
+
+        if (presetIndex !in 0 until numberOfPresets) {
+            return false
+        }
+
+        return runCatching {
+            effect.usePreset(presetIndex.toShort())
+        }.isSuccess
     }
 
     fun getBandLevel(bandIndex: Int): Short? {
@@ -153,17 +166,21 @@ object AudioEffectManager {
         }
     }
 
-    /**
-     * - Fragment는 체인 생성/파괴를 하지 않고, 현재 저장된 설정값을 네이티브에 반영.
-     * - EQ band 값은 prefs에 저장된 progress를 dB로 변환해서 반영.
-     */
+    // 저장된 음향 효과 값을 현재 AudioEffect 상태에 다시 반영한다.
     fun applySettingsFromPrefs(
         prefs: SharedPreferences,
         bandCount: Int = bandGainsDb.size,
         eqMaxFromUi: Int,
     ) {
+        // 저장값이 없으면 중앙값인 0 dB를 사용한다.
+        val neutralProgress = (eqMaxFromUi / 2).coerceIn(0, eqMaxFromUi)
+
         for (bandIndex in 0 until bandCount) {
-            val progress = prefs.getInt(bandIndex.toString(), 0)
+            val progress = prefs.getInt(
+                bandIndex.toString(),
+                neutralProgress,
+            ).coerceIn(0, eqMaxFromUi)
+
             val gainDb = mapEqProgressToDb(progress, eqMaxFromUi)
             setBandGain(bandIndex, gainDb)
         }

--- a/app/src/main/java/com/hero/ziggymusic/playback/service/MusicService.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/service/MusicService.kt
@@ -22,16 +22,22 @@ import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaStyleNotificationHelper
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.data.local.entity.MusicTrackEntity
+import com.hero.ziggymusic.domain.audio.repository.AudioSettingsRepository
+import com.hero.ziggymusic.playback.manager.AudioEffectManager
 import com.hero.ziggymusic.playback.state.PlayerStateHolder
 import com.hero.ziggymusic.playback.queue.PlaybackQueueManager
 import com.hero.ziggymusic.presentation.main.MainActivity
 import javax.inject.Inject
 import dagger.hilt.android.AndroidEntryPoint
 
+@OptIn(UnstableApi::class)
 @AndroidEntryPoint
 class MusicService : MediaLibraryService() {
     @Inject
     lateinit var player: ExoPlayer
+
+    @Inject
+    lateinit var audioSettingsRepository: AudioSettingsRepository
 
     @Inject
     lateinit var playbackQueueManager: PlaybackQueueManager
@@ -40,6 +46,8 @@ class MusicService : MediaLibraryService() {
 
     @Volatile
     private var isExiting: Boolean = false
+
+    private var attachedAudioSessionId: Int = 0
 
     private val playerListener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -65,6 +73,11 @@ class MusicService : MediaLibraryService() {
 
             updateNotification()
         }
+
+        override fun onAudioSessionIdChanged(audioSessionId: Int) {
+            if (isExiting) return
+            attachAudioEffects(audioSessionId)
+        }
     }
 
     private lateinit var mediaLibrarySession: MediaLibrarySession
@@ -84,6 +97,9 @@ class MusicService : MediaLibraryService() {
         MusicServiceState.onForegroundEntered()
 
         player.addListener(playerListener)
+
+        // 서비스 시작 시 이미 생성된 오디오 세션이 있으면 즉시 효과를 연결한다.
+        attachAudioEffects(player.audioSessionId)
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
@@ -319,6 +335,17 @@ class MusicService : MediaLibraryService() {
         )
     }
 
+    // 오디오 세션이 바뀌면 효과를 다시 연결하고 저장된 설정을 복원한다.
+    private fun attachAudioEffects(audioSessionId: Int) {
+        if (audioSessionId == 0) return
+        if (audioSessionId == attachedAudioSessionId) return
+
+        AudioEffectManager.init(audioSessionId)
+        audioSettingsRepository.applySavedSettings()
+
+        attachedAudioSessionId = audioSessionId
+    }
+
     override fun onTaskRemoved(rootIntent: Intent?) {
         exitPlayer()
         super.onTaskRemoved(rootIntent)
@@ -351,6 +378,12 @@ class MusicService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
+        player.removeListener(playerListener)
+
+        // 서비스 종료 시 오디오 세션에 연결된 효과 리소스를 해제한다.
+        AudioEffectManager.release()
+        attachedAudioSessionId = 0
+
         MusicServiceState.reset()
 
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -12,22 +12,18 @@ import android.view.MenuItem
 import android.view.WindowManager
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.navigation.NavigationBarView
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.playback.state.PlayerStateHolder
 import com.hero.ziggymusic.databinding.ActivityMainBinding
-import com.hero.ziggymusic.playback.manager.AudioEffectManager
 import com.hero.ziggymusic.presentation.main.setting.AudioSettingsFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -56,7 +52,6 @@ import com.hero.ziggymusic.presentation.main.musictracks.viewmodel.MusicTracksVi
 import com.hero.ziggymusic.presentation.main.popup.MusicTracksSortMenuPopup
 import com.hero.ziggymusic.presentation.main.setting.AppSettingsFragment
 import com.hero.ziggymusic.presentation.main.setting.WebPageFragment
-import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import com.hero.ziggymusic.presentation.main.setting.LicenseNoticesFragment
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -67,7 +62,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
     private val vm by viewModels<MainViewModel>()
     private val playerVm by viewModels<PlayerViewModel>()
     private val musicTracksVm by viewModels<MusicTracksViewModel>()
-    private val audioSettingsVm by viewModels<AudioSettingsViewModel>()
 
     @Inject
     lateinit var player: ExoPlayer
@@ -89,7 +83,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         initBottomNavigationView()
         initViewModel()
         initPlayerController()
-        initSoundEQSettings()
         initListeners()
         requestPermissions()
     }
@@ -864,24 +857,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         } else {
             ViewCompat.setOnApplyWindowInsetsListener(binding.containerPlayer, null)
             binding.containerPlayer.setPadding(0, 0, 0, 0)
-        }
-    }
-
-    @OptIn(UnstableApi::class)
-    private fun initSoundEQSettings() {
-        if (player.audioSessionId != 0) {
-            AudioEffectManager.init(player.audioSessionId)
-            audioSettingsVm.applySavedSettings()
-        } else {
-            player.addListener(object : Player.Listener {
-                override fun onAudioSessionIdChanged(audioSessionId: Int) {
-                    if (audioSessionId != 0) {
-                        AudioEffectManager.init(audioSessionId)
-                        audioSettingsVm.applySavedSettings()
-                        player.removeListener(this)
-                    }
-                }
-            })
         }
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/audioeffect/AudioEffectBottomSheetDialogFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -21,6 +22,7 @@ import com.google.android.material.button.MaterialButton
 import com.hero.ziggymusic.R
 import com.hero.ziggymusic.data.local.preferences.AudioSettingKeys
 import com.hero.ziggymusic.databinding.FragmentAudioEffectBottomSheetBinding
+import com.hero.ziggymusic.playback.manager.AudioEffectManager
 import com.hero.ziggymusic.presentation.main.setting.model.AudioSettingsUiState
 import com.hero.ziggymusic.presentation.main.setting.viewmodel.AudioSettingsViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -192,34 +194,62 @@ class AudioEffectBottomSheetDialogFragment : BottomSheetDialogFragment() {
         isApplyingAudioSettingsState = false
     }
 
-    // 최근 프리셋 position 목록을 버튼 모델로 변환하고 각 MaterialButton의 표시 텍스트를 갱신한다.
+    // 현재 기기가 지원하는 프리셋만 버튼에 표시한다.
     private fun updateRecentPresetButtons(recentPresetPositions: List<Int>) {
-        recentPresets = buildRecentPresetButtonModels(recentPresetPositions)
+        recentPresets =
+            buildRecentPresetButtonModels(recentPresetPositions)
 
         recentPresetButtonIds.forEachIndexed { index, buttonId ->
-            val preset = recentPresets.getOrNull(index) ?: return@forEachIndexed
-            binding.togglePresetGroup.findViewById<MaterialButton>(buttonId)?.text =
-                getString(preset.labelResId)
+            val button =
+                binding.togglePresetGroup.findViewById<MaterialButton>(
+                    buttonId,
+                )
+
+            val preset = recentPresets.getOrNull(index)
+
+            button.isVisible = preset != null
+            button.isEnabled = preset != null
+
+            if (preset != null) {
+                button.text = getString(preset.labelResId)
+            }
         }
     }
 
-    // Custom은 사용자가 직접 조정한 EQ 상태를 되돌리는 진입점이므로 마지막 버튼에 고정하고,
-    // 일반 EQ 프리셋만 최근 선택 순서대로 앞 3개 버튼에 배치한다.
+    // 지원되는 최근 프리셋을 우선 배치하고 부족한 항목은 지원 프리셋으로 채운다.
     private fun buildRecentPresetButtonModels(
         recentPresetPositions: List<Int>,
     ): List<AudioEffectPreset> {
-        // 저장된 position 값을 바텀시트 프리셋 모델로 변환한 일반 EQ 프리셋 목록
-        val nonCustomPresets = recentPresetPositions
+        val maxSupportedPresetPosition =
+            AudioEffectManager.getNumberOfPresets()
+                .coerceAtLeast(0)
+
+        val supportedPresets = AudioEffectPreset.entries
+            .filter { preset ->
+                preset == AudioEffectPreset.CUSTOM ||
+                        preset.config.settingsPresetPosition in
+                        1..maxSupportedPresetPosition
+            }
+
+        val recentNonCustomPresets = recentPresetPositions
             .mapNotNull(::findPresetBySettingsPosition)
-            .filterNot { it == AudioEffectPreset.CUSTOM }
+            .filter { preset ->
+                preset != AudioEffectPreset.CUSTOM &&
+                        preset in supportedPresets
+            }
             .distinct()
 
-        // 저장된 목록이 부족하거나 유효하지 않을 때 빈 슬롯을 채울 기본 프리셋 후보
-        val fallbackPresets = defaultRecentPresets
-            .filterNot { it == AudioEffectPreset.CUSTOM || it in nonCustomPresets }
+        val fallbackPresets = supportedPresets
+            .filterNot { preset ->
+                preset == AudioEffectPreset.CUSTOM ||
+                        preset in recentNonCustomPresets
+            }
 
-        return (nonCustomPresets + fallbackPresets)
-            .take(RECENT_NON_CUSTOM_PRESET_COUNT) + AudioEffectPreset.CUSTOM
+        return (
+                recentNonCustomPresets + fallbackPresets
+                )
+            .take(RECENT_NON_CUSTOM_PRESET_COUNT) +
+                AudioEffectPreset.CUSTOM
     }
 
     // 설정 화면의 spinner position 값에 대응하는 바텀시트 프리셋 모델을 찾는다.

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,7 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude
+        domain="sharedpref"
+        path="audio_settings.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude
+            domain="sharedpref"
+            path="audio_settings.xml" />
     </cloud-backup>
-    <!--
+
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude
+            domain="sharedpref"
+            path="audio_settings.xml" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
# PR 내용
1. Custom EQ 기본값 및 저장 호환성 개선
- 저장값이 없거나 기기 EQ 구성과 호환되지 않으면 0 dB로 초기화
- 밴드 수와 레벨 범위를 함께 저장해 잘못된 Custom 값 복원 방지

2. 오디오 세션 변경 시 음향 설정 복원
- EQ 초기화 책임을 MainActivity에서 MusicService로 이전
- 오디오 세션 변경 시 저장 설정을 다시 적용하고 서비스 종료 시 리소스 해제

3. EQ 프리셋 검증 및 UI 안정성 개선
- 기기가 지원하는 프리셋 범위로 저장값과 요청값 보정
- 지원되지 않는 프리셋을 바텀시트에서 제외하고 적용 실패 시 Custom으로 전환

4. 기기 종속 음향 설정 백업 제외
- 클라우드 백업과 기기 간 이전에서 audio_settings.xml 제외
- Android 11 이하와 Android 12 이상 백업 규칙을 각각 적용