### PR TITLE
[ Fix ] MediaController 연결 실패 처리 및 재생 제어 안정성 개선

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/playback/service/MusicMediaControllerConnector.kt
+++ b/app/src/main/java/com/hero/ziggymusic/playback/service/MusicMediaControllerConnector.kt
@@ -2,35 +2,94 @@ package com.hero.ziggymusic.playback.service
 
 import android.content.ComponentName
 import android.content.Context
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class MusicMediaControllerConnector(context: Context) {
     private val appContext = context.applicationContext
+
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var controller: MediaController? = null
 
-    suspend fun connect(): MediaController {
+    /**
+     * 이미 연결된 MediaController가 있으면 재사용한다.
+     *
+     * 연결에 성공하면 MediaController를 반환하고,
+     * 코루틴 취소를 제외한 연결 실패는 기록한 뒤 null을 반환한다.
+     *
+     * CancellationException은 구조화된 동시성과 생명주기 취소를
+     * 유지하기 위해 호출자에게 다시 전달한다.
+     */
+    suspend fun connect(): MediaController? {
         val currentController = controller
+
         if (currentController?.isConnected == true) {
             return currentController
         }
 
-        val connectedController = getOrCreateControllerFuture().awaitController()
-        controller = connectedController
-        return connectedController
+        var connectionFuture: ListenableFuture<MediaController>? = null
+
+        return try {
+            val future = getOrCreateControllerFuture()
+            connectionFuture = future
+
+            val connectedController = future.awaitController()
+
+            if (!connectedController.isConnected) {
+                invalidateConnection(future)
+                null
+            } else {
+                controller = connectedController
+                connectedController
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "MediaController 연결 실패", e)
+
+            connectionFuture?.let { failedFuture ->
+                invalidateConnection(failedFuture)
+            } ?: invalidateConnection()
+
+            null
+        }
     }
 
-    suspend fun withController(action: (MediaController) -> Unit) {
-        val controller = connect()
-        if (controller.isConnected) {
-            action(controller)
+    /**
+     * 연결된 MediaController를 사용해 명령을 실행한다.
+     *
+     * 명령이 정상적으로 실행되면 true를 반환한다.
+     * 코루틴 취소를 제외한 연결 또는 명령 실행 실패는
+     * 내부에서 기록한 뒤 false를 반환한다.
+     */
+    suspend fun withController(
+        action: (MediaController) -> Unit
+    ): Boolean {
+        return try {
+            val connectedController = connect() ?: return false
+
+            if (!connectedController.isConnected) {
+                invalidateConnection()
+                false
+            } else {
+                action(connectedController)
+                true
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "MediaController 명령 실행 실패", e)
+
+            invalidateConnection()
+            false
         }
     }
 
@@ -42,9 +101,12 @@ class MusicMediaControllerConnector(context: Context) {
             appContext,
             ComponentName(appContext, MusicService::class.java)
         )
-        val future = MediaController.Builder(appContext, sessionToken).buildAsync()
-        controllerFuture = future
-        return future
+
+        return MediaController.Builder(appContext, sessionToken)
+            .buildAsync()
+            .also { future ->
+                controllerFuture = future
+            }
     }
 
     private suspend fun ListenableFuture<MediaController>.awaitController(): MediaController {
@@ -66,9 +128,36 @@ class MusicMediaControllerConnector(context: Context) {
         }
     }
 
-    fun release() {
+    /**
+     * 전달된 Future가 현재 Future인 경우에만 폐기한다.
+     * 이전 연결의 늦은 실패가 새 연결을 제거하는 상황을 방지한다.
+     */
+    @Synchronized
+    private fun invalidateConnection(
+        expectedFuture: ListenableFuture<MediaController>? = null
+    ) {
+        if (expectedFuture != null && controllerFuture !== expectedFuture) {
+            return
+        }
+
         controller = null
-        controllerFuture?.let(MediaController::releaseFuture)
+
+        controllerFuture?.let { future ->
+            runCatching {
+                MediaController.releaseFuture(future)
+            }.onFailure { error ->
+                Log.w(TAG, "MediaController Future 해제 실패", error)
+            }
+        }
+
         controllerFuture = null
+    }
+
+    fun release() {
+        invalidateConnection()
+    }
+
+    companion object {
+        private const val TAG = "MediaControllerConnector"
     }
 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/PlayerFragment.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/PlayerFragment.kt
@@ -175,8 +175,13 @@ class PlayerFragment : Fragment() {
 
     private fun initMediaController() {
         mediaControllerConnector = MusicMediaControllerConnector(requireContext())
+
         viewLifecycleOwner.lifecycleScope.launch {
-            mediaControllerConnector.connect()
+            val controller = mediaControllerConnector.connect()
+
+            if (controller == null) {
+                Log.e(TAG, "MediaController 초기 연결에 실패했습니다.")
+            }
         }
     }
 
@@ -525,12 +530,17 @@ class PlayerFragment : Fragment() {
     private fun initPlayControlButtons() {
         binding.ivPlayPause.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
-                mediaControllerConnector.withController { controller ->
-                    if (player.isPlaying) {
-                        controller.pause()
-                    } else {
-                        controller.play()
+                val executed =
+                    mediaControllerConnector.withController { controller ->
+                        if (player.isPlaying) {
+                            controller.pause()
+                        } else {
+                            controller.play()
+                        }
                     }
+
+                if (!executed) {
+                    showPlaybackControlUnavailableMessage()
                 }
             }
         }
@@ -545,19 +555,37 @@ class PlayerFragment : Fragment() {
             }
 
             viewLifecycleOwner.lifecycleScope.launch {
-                mediaControllerConnector.withController { controller ->
-                    controller.seekToNext()
+                val executed =
+                    mediaControllerConnector.withController { controller ->
+                        controller.seekToNext()
+                    }
+
+                if (!executed) {
+                    showPlaybackControlUnavailableMessage()
                 }
             }
         }
 
         binding.ivPrevious.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
-                mediaControllerConnector.withController { controller ->
-                    controller.seekToPrevious()
+                val executed =
+                    mediaControllerConnector.withController { controller ->
+                        controller.seekToPrevious()
+                    }
+
+                if (!executed) {
+                    showPlaybackControlUnavailableMessage()
                 }
             }
         }
+    }
+
+    private fun showPlaybackControlUnavailableMessage() {
+        Toast.makeText(
+            context,
+            R.string.playback_control_unavailable,
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     private fun moveToFirstTrack(): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,10 @@
         <item>설정</item>
     </string-array>
 
+    <!-- Player -->
     <string name="current_playing_time">0:00</string>
     <string name="total_playing_time">3:10</string>
+    <string name="playback_control_unavailable">재생 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.</string>
 
     <string name="current_song_title">제목</string>
     <string name="current_song_artist">아티스트</string>


### PR DESCRIPTION
# PR 내용
1. MediaController 연결 실패 처리 보완
- 연결 및 Future 생성 예외를 기록하고 null로 안전하게 처리
- 실패하거나 연결이 끊긴 Future를 해제하여 재연결이 가능하도록 개선
- 생명주기 취소를 위한 CancellationException은 호출자에게 다시 전파

2. 재생 제어 명령 안정성 개선
- 컨트롤러 명령 실행 결과를 Boolean으로 반환
- 재생, 이전 곡, 다음 곡 명령 실패가 UI 코루틴 크래시로 이어지지 않도록 처리

3. 연결 실패 사용자 안내 추가
- 초기 연결 실패 로그 처리
- 재생 제어 실패 시 안내 메시지 표시
- 사용자 안내 문구를 문자열 리소스로 관리