### PR TITLE
[ Performance ] 앱 시작 성능 개선 및 플레이어 초기화 안정화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,19 @@ extensions.configure<ApplicationExtension> {
             isDebuggable = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+        // release와 동일한 최적화 조건으로 로컬 성능을 측정한다.
+        create("benchmark") {
+            initWith(getByName("release"))
+
+            // 로컬 설치용. 실제 release 서명키는 사용하지 않음
+            signingConfig = signingConfigs.getByName("debug")
+
+            // debug 앱과 동시에 설치하려면 사용
+            applicationIdSuffix = ".benchmark"
+            versionNameSuffix = "-benchmark"
+
+            matchingFallbacks += listOf("release")
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.core.net.toUri
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import androidx.media3.exoplayer.ExoPlayer
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.navigation.NavigationBarView
 import com.hero.ziggymusic.R
@@ -28,7 +27,6 @@ import com.hero.ziggymusic.databinding.ActivityMainBinding
 import com.hero.ziggymusic.presentation.main.setting.AudioSettingsFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -66,12 +64,21 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
     private val musicTracksVm by viewModels<MusicTracksViewModel>()
     private val favoriteMusicTracksVm by viewModels<FavoriteMusicTracksViewModel>()
 
-    @Inject
-    lateinit var player: ExoPlayer
-
     private val playerStateHolder: PlayerStateHolder = PlayerStateHolder.getInstance()
     private lateinit var playerController: PlayerController
     private val lastPlaybackStore by lazy { LastPlaybackStore(this) }
+
+    private enum class InitialMainTabState {
+        NOT_STARTED,
+        SCHEDULED,
+        READY,
+    }
+
+    private var initialMainTabState = InitialMainTabState.NOT_STARTED
+
+    private var isPlayerStartupRequested = false
+    private var isPlayerStateObservationStarted = false
+    private var isMusicTrackObservationStarted = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -87,6 +94,8 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         initViewModel()
         initPlayerController()
         initListeners()
+
+        scheduleInitialContentSetup()
         requestPermissions()
     }
 
@@ -171,8 +180,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             vm.requestOpenAppSettings()
         }
 
-        initMainTabFragments()
-
         binding.bottomNavMain.setOnItemSelectedListener(this)
 
         // 현재 탭에서 열린 설정 흐름은 탭 재선택 시 닫는다.
@@ -184,8 +191,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                 }
             }
         }
-
-        prepareFavoritesTabAfterFirstDraw()
     }
 
     // 현재 메인 탭을 숨기고 앱 설정을 설정 흐름의 첫 화면으로 표시한다.
@@ -372,26 +377,26 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
     override fun onResume() {
         super.onResume()
 
-        playerVm.refreshFavoriteTrackOrderForCurrentLanguage()
-        startPlayerIfAudioPermissionGranted()
+        // 첫 draw 이후 PlayerViewModel이 이미 초기화된 경우에만
+        // 언어 변경에 따른 정렬을 갱신한다.
+        if (isPlayerStateObservationStarted) {
+            playerVm.refreshFavoriteTrackOrderForCurrentLanguage()
+        }
+
+        scheduleInitialContentSetup()
+        schedulePlayerStartupIfReady()
     }
 
     private fun initViewModel() {
         with(vm) {
-            lifecycleScope.launch {
-                musicTracks.observe(this@MainActivity) { musicTracks ->
-                    playerStateHolder.replaceMusicTrackList(musicTracks)
-                }
-
-                // Title과 UI 상태를 한번에 관찰
-                currentTitle.observe(this@MainActivity) { mainTitle ->
-                    binding.tvMainTitle.text = getString(mainTitle.resId)
-                    binding.ivBack.isVisible = mainTitle.showBackButton
-                    binding.ivSortMusicTracks.isVisible = mainTitle.showMusicTrackSortButton
-                    binding.ivSortMusicTracks.isEnabled = mainTitle.showMusicTrackSortButton
-                    binding.ivAppSettings.isVisible = mainTitle.showAppSettingsButton
-                    binding.ivAppSettings.isEnabled = mainTitle.showAppSettingsButton
-                }
+            // Title과 UI 상태를 한번에 관찰
+            currentTitle.observe(this@MainActivity) { mainTitle ->
+                binding.tvMainTitle.text = getString(mainTitle.resId)
+                binding.ivBack.isVisible = mainTitle.showBackButton
+                binding.ivSortMusicTracks.isVisible = mainTitle.showMusicTrackSortButton
+                binding.ivSortMusicTracks.isEnabled = mainTitle.showMusicTrackSortButton
+                binding.ivAppSettings.isVisible = mainTitle.showAppSettingsButton
+                binding.ivAppSettings.isEnabled = mainTitle.showAppSettingsButton
             }
 
             navigationEvent.observe(this@MainActivity) { event ->
@@ -412,15 +417,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                     null -> Unit
                 }
             }
-        }
-
-        lifecycleScope.launch {
-            playerVm.motionState
-                .map { it == PlayerMotionManager.State.EXPANDED }
-                .distinctUntilChanged()
-                .collect { expanded ->
-                    setPlayerExpandedMode(expanded)
-                }
         }
     }
 
@@ -573,46 +569,74 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             }
     }
 
-    // 첫 화면 렌더링 이후 즐겨찾기 탭을 미리 준비한다.
-    private fun prepareFavoritesTabAfterFirstDraw() {
+    // 첫 프레임을 우선 표시한 뒤 메인 탭과 데이터 관찰을 초기화한다.
+    private fun scheduleInitialContentSetup() {
+        if (initialMainTabState != InitialMainTabState.NOT_STARTED) return
+
+        initialMainTabState = InitialMainTabState.SCHEDULED
+
         binding.root.doOnPreDraw {
             binding.root.post {
-                prepareFavoritesTabFragment()
+                // 상태 저장 이후의 Fragment 커밋을 피한다.
+                val canCommitFragment =
+                    !isFinishing &&
+                            !isDestroyed &&
+                            lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) &&
+                            !supportFragmentManager.isDestroyed &&
+                            !supportFragmentManager.isStateSaved
+
+                if (!canCommitFragment) {
+                    // onResume에서 초기화를 다시 예약할 수 있게 한다.
+                    initialMainTabState = InitialMainTabState.NOT_STARTED
+                    return@post
+                }
+
+                initMainTabFragments()
+                startObservingMusicTracksForPlayer()
+
+                // 추가된 음악 프래그먼트가 최소 한 번 그려진 다음 플레이어를 시작한다.
+                binding.fcvMain.doOnPreDraw {
+                    initialMainTabState = InitialMainTabState.READY
+
+                    binding.fcvMain.post {
+                        schedulePlayerStartupIfReady()
+                    }
+                }
             }
         }
     }
 
-    // 즐겨찾기 탭 프래그먼트를 숨긴 상태로 미리 추가한다.
-    private fun prepareFavoritesTabFragment() {
-        if (isFinishing || isDestroyed) {
+    // 첫 프레임 이후 Room 관찰을 시작해 시작 구간의 DB 초기화를 미룬다.
+    private fun startObservingMusicTracksForPlayer() {
+        if (isMusicTrackObservationStarted) {
             return
         }
 
-        // 화면 상태가 이미 저장된 이후에는 Fragment 트랜잭션을 실행하지 않는다.
-        if (supportFragmentManager.isStateSaved) {
+        isMusicTrackObservationStarted = true
+
+        musicTracksVm.musicTrackList.observe(this) { musicTracks ->
+            playerStateHolder.replaceMusicTrackList(musicTracks)
+        }
+    }
+
+    // 플레이어 시작 시점에 ViewModel과 상태 관찰을 한 번만 초기화한다.
+    private fun initPlayerVmObservers() {
+        if (isPlayerStateObservationStarted) {
             return
         }
 
-        // 화면 회전 복원이나 이전 초기화로 이미 존재하면 재생성하지 않는다.
-        if (supportFragmentManager.findFragmentByTag(TAG_FAVORITES) != null) {
-            return
+        isPlayerStateObservationStarted = true
+
+        playerVm.refreshFavoriteTrackOrderForCurrentLanguage()
+
+        lifecycleScope.launch {
+            playerVm.motionState
+                .map { it == PlayerMotionManager.State.EXPANDED }
+                .distinctUntilChanged()
+                .collect { expanded ->
+                    setPlayerExpandedMode(expanded)
+                }
         }
-
-        val favoriteMusicTracksFragment = FavoriteMusicTracksFragment.newInstance()
-
-        supportFragmentManager.beginTransaction()
-            .setReorderingAllowed(true)
-            .add(
-                binding.fcvMain.id,
-                favoriteMusicTracksFragment,
-                TAG_FAVORITES
-            )
-            .hide(favoriteMusicTracksFragment)
-            .setMaxLifecycle(
-                favoriteMusicTracksFragment,
-                Lifecycle.State.STARTED
-            )
-            .commitNow()
     }
 
     private fun startMusicServiceIfNotificationAllowed() {
@@ -705,7 +729,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
             }
         }
         if (needs.isEmpty()) {
-            startPlayerIfAudioPermissionGranted()
+            schedulePlayerStartupIfReady()
         } else {
             permissionLauncher.launch(needs.toTypedArray())
         }
@@ -729,7 +753,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         }
 
         // 오디오 권한 허용됨 -> 핵심 기능 시작
-        startPlayerIfAudioPermissionGranted()
+        schedulePlayerStartupIfReady()
 
         // 알림 권한 선택적 처리
         if (!notifGranted) {
@@ -742,12 +766,62 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         }
     }
 
-    private fun startPlayerIfAudioPermissionGranted() {
-        if (!hasAudioPermission()) return
+    private fun schedulePlayerStartupIfReady() {
+        if (
+            !hasAudioPermission() ||
+            initialMainTabState != InitialMainTabState.READY ||
+            isPlayerStartupRequested
+        ) {
+            return
+        }
 
-        playerController.startPlayer(
-            lastPlaybackStore.loadLastPlayedId(PlaybackContentType.MUSIC).orEmpty()
+        isPlayerStartupRequested = true
+
+        val startAction = Runnable {
+            tryStartPlayerNow()
+        }
+
+        if (binding.root.isLaidOut) {
+            // 첫 draw가 이미 끝난 재진입 상황
+            binding.root.post(startAction)
+        } else {
+            // 최초 실행에서는 첫 draw 이후 실행
+            binding.root.doOnPreDraw {
+                binding.root.post(startAction)
+            }
+        }
+    }
+
+    // onSaveInstanceState 이후의 Fragment 트랜잭션을 막기 위해 RESUMED 상태에서만 시작한다.
+    private fun tryStartPlayerNow() {
+        val canStartPlayer =
+            !isFinishing &&
+                    !isDestroyed &&
+                    hasAudioPermission() &&
+                    lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED) &&
+                    !supportFragmentManager.isDestroyed &&
+                    !supportFragmentManager.isStateSaved
+
+        if (!canStartPlayer) {
+            // 다음 onResume에서 다시 예약할 수 있게 한다.
+            isPlayerStartupRequested = false
+            return
+        }
+
+        initPlayerVmObservers()
+
+        val playerStartAccepted = playerController.startPlayer(
+            lastPlaybackStore
+                .loadLastPlayedId(PlaybackContentType.MUSIC)
+                .orEmpty()
         )
+
+        if (!playerStartAccepted) {
+            // PlayerController의 최종 가드에서 거절된 경우에도 재시도 허용
+            isPlayerStartupRequested = false
+            return
+        }
+
         startMusicServiceIfNotificationAllowed()
     }
 

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainViewModel.kt
@@ -3,8 +3,6 @@ package com.hero.ziggymusic.presentation.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.hero.ziggymusic.data.local.entity.MusicTrackEntity
-import com.hero.ziggymusic.domain.music.repository.MusicRepository
 import com.hero.ziggymusic.presentation.common.SingleEvent
 import com.hero.ziggymusic.presentation.main.model.MainTitle
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,11 +17,7 @@ sealed class MainNavigationCommand {
 }
 
 @HiltViewModel
-class MainViewModel @Inject constructor(
-    private val musicRepository: MusicRepository
-): ViewModel() {
-    val musicTracks: LiveData<List<MusicTrackEntity>> = musicRepository.observeMusicTracks()
-
+class MainViewModel @Inject constructor() : ViewModel() {
     // MainTitle 상태 관리
     private val _currentTitle = MutableLiveData<MainTitle>(MainTitle.MusicTracks)
     val currentTitle: LiveData<MainTitle> = _currentTitle

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/viewmodel/MusicTracksViewModel.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/musictracks/viewmodel/MusicTracksViewModel.kt
@@ -88,7 +88,7 @@ class MusicTracksViewModel @Inject constructor(
 
     private val allMusicTracksObserver = Observer<List<MusicTrackEntity>> { musicTracks ->
         if (musicTracks.isNotEmpty()) {
-            updateMusicTrackListUiState(musicTracks)
+            updateMusicTrackListUiStateIfNeeded(musicTracks)
         }
     }
 
@@ -96,6 +96,24 @@ class MusicTracksViewModel @Inject constructor(
         // Observer 는 항상 활성 상태로 간주되므로 항상 수정 관련 알림을 받는다.
         musicTrackList.observeForever(allMusicTracksObserver)
         observeSearchQuery()
+    }
+
+    // Room과 MediaStore가 같은 목록을 연속 전달해도 UI 상태는 한 번만 갱신한다.
+    private fun updateMusicTrackListUiStateIfNeeded(
+        trackList: List<MusicTrackEntity>,
+    ) {
+        val isTrackListUiStateUpToDate =
+            (
+                _uiState.value is MusicTrackListUiState.Content ||
+                    _uiState.value is MusicTrackListUiState.Empty
+            ) &&
+                trackList == currentMusicTracks
+
+        if (isTrackListUiStateUpToDate) {
+            return
+        }
+
+        updateMusicTrackListUiState(trackList)
     }
 
     // MediaStore에서 최신 음악 목록을 조회하고, UI 갱신 후 Room 캐시를 갱신한다.
@@ -109,7 +127,7 @@ class MusicTracksViewModel @Inject constructor(
             runCatching {
                 musicRepository.getMusicTracksFromMediaStore()
             }.onSuccess { trackList ->
-                updateMusicTrackListUiState(trackList)
+                updateMusicTrackListUiStateIfNeeded(trackList)
 
                 // 사용자에게 먼저 목록을 보여준 뒤 캐시를 저장한다.
                 musicRepository.replaceCachedMusicTracks(trackList)

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/player/manager/PlayerController.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/player/manager/PlayerController.kt
@@ -5,13 +5,14 @@ import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.hero.ziggymusic.playback.queue.PlaybackQueueSource
 import com.hero.ziggymusic.presentation.main.player.PlayerFragment
 
 class PlayerController(
-    lifecycleOwner: LifecycleOwner,
+    private val lifecycleOwner: LifecycleOwner,
     private val fragmentContainer: ViewGroup,
     private val fragmentManager: FragmentManager,
     private val onStateChanged: (newState: Int) -> Unit
@@ -34,18 +35,39 @@ class PlayerController(
 
     private var isBottomSheetCallbackAdded = false
 
+    // 비동기 Fragment 커밋이 끝나기 전 중복 추가를 막는다.
+    private var isPlayerFragmentAddPending = false
+
     init {
         lifecycleOwner.lifecycle.addObserver(this)
     }
 
-    fun startPlayer(initialTrackId: String = "") {
-        if (playerFragment == null) {
+    fun startPlayer(initialTrackId: String = ""): Boolean {
+        val canCommitFragment =
+            !fragmentManager.isDestroyed &&
+                    !fragmentManager.isStateSaved &&
+                    lifecycleOwner.lifecycle.currentState
+                        .isAtLeast(Lifecycle.State.RESUMED)
+
+        if (!canCommitFragment) {
+            return false
+        }
+
+        if (playerFragment == null && !isPlayerFragmentAddPending) {
+            isPlayerFragmentAddPending = true
+
             fragmentManager.commit {
+                setReorderingAllowed(true)
+
                 add(
                     fragmentContainer.id,
                     PlayerFragment.newInstance(initialTrackId),
                     PlayerFragment.TAG
                 )
+
+                runOnCommit {
+                    isPlayerFragmentAddPending = false
+                }
             }
         }
 
@@ -53,6 +75,8 @@ class PlayerController(
             bottomSheetBehavior.addBottomSheetCallback(callback)
             isBottomSheetCallbackAdded = true
         }
+
+        return true
     }
 
     fun changeMusic(

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -3,7 +3,6 @@
     <!-- Android 12+ night application theme -->
     <style name="Theme.ZiggyMusic" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="windowNoTitle">true</item>
-        <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
 
         <!-- Default text style -->

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -22,7 +22,5 @@
         <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
-    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
-        <item name="android:windowDisablePreview">true</item>
-    </style>
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic" />
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -3,7 +3,6 @@
     <!-- Android 12+ application theme -->
     <style name="Theme.ZiggyMusic" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="windowNoTitle">true</item>
-        <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowContentOverlay">@null</item>
 
         <!-- Default text style -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,9 +22,7 @@
         <item name="android:windowBackground">@color/main_dark_gradient_start</item>
     </style>
 
-    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic">
-        <item name="android:windowDisablePreview">true</item>
-    </style>
+    <style name="Theme.ZiggyMusic.Launcher" parent="Theme.ZiggyMusic" />
 
     <style name="SpinnerDivideStyle" parent="android:style/Widget.ListView.DropDown">
         <item name="android:divider">@color/white</item>


### PR DESCRIPTION
# PR 내용
1. 앱 시작 시 초기화 작업을 첫 프레임 이후로 지연
- 메인 탭과 음악 목록 관찰을 첫 화면 표시 이후에 초기화
- `PlayerViewModel` 상태 관찰과 플레이어 시작 시점을 지연
- `MainViewModel`의 불필요한 Repository 의존성과 ExoPlayer 조기 주입 제거

2. `PlayerFragment` 시작 안정성 개선
- Activity가 RESUMED 상태이고 Fragment 상태가 저장되지 않은 경우에만 플레이어 시작
- 비동기 Fragment 커밋의 중복 요청을 방지하고 시작 실패 시 onResume에서 재시도

3. 음악 목록 상태 갱신 최적화
- MediaStore와 Room에서 동일한 목록이 연속 전달될 때 중복 UI 갱신 방지
- 음악 목록 관찰 시작 시점을 조정해 앱 시작 구간의 Room 초기화 지연

4. 런처 초기 화면과 성능 측정 환경 개선
- 불투명한 런처 배경 Preview를 사용하도록 테마 설정 조정
- release와 동일한 최적화 조건으로 측정할 수 있는 benchmark 빌드 타입 추가