### PR TITLE
[ UI ] 음악 목록/즐겨찾기 목록 정렬 항목 '추가된 날짜' Resource 변경 

### DIFF
--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/MainActivity.kt
@@ -156,7 +156,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                         selectedSortOrder =
                             musicTracksVm.sortOrder.value
                                 ?: MusicTrackSortOrder.TITLE_ASCENDING,
-                        dateAddedLabelResId = R.string.sort_added_to_music_tracks_date,
+                        dateAddedLabelResId = R.string.sort_added_date,
                         onSelected = musicTracksVm::setMusicTrackSortOrder,
                     )
                 }
@@ -166,7 +166,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
                         selectedSortOrder =
                             favoriteMusicTracksVm.sortOrder.value
                                 ?: MusicTrackSortOrder.DATE_ADDED_DESCENDING,
-                        dateAddedLabelResId = R.string.sort_added_to_favorite_music_tracks_date,
+                        dateAddedLabelResId = R.string.sort_added_date,
                         onSelected = favoriteMusicTracksVm::setSortOrder,
                     )
                 }

--- a/app/src/main/java/com/hero/ziggymusic/presentation/main/popup/MusicTrackSortMenuPopup.kt
+++ b/app/src/main/java/com/hero/ziggymusic/presentation/main/popup/MusicTrackSortMenuPopup.kt
@@ -17,7 +17,7 @@ class MusicTrackSortMenuPopup(
     private val anchorView: View,
     private val selectedSortOrder: MusicTrackSortOrder,
     @get:StringRes
-    private val dateAddedLabelResId: Int = R.string.sort_added_to_music_tracks_date,
+    private val dateAddedLabelResId: Int = R.string.sort_added_date,
     private val onSortOrderSelected: (MusicTrackSortOrder) -> Unit,
 ) {
     fun show() {

--- a/app/src/main/res/layout/popup_music_track_sort_menu.xml
+++ b/app/src/main/res/layout/popup_music_track_sort_menu.xml
@@ -145,7 +145,7 @@
             android:layout_weight="1"
             android:ellipsize="end"
             android:maxLines="1"
-            android:text="@string/sort_added_to_music_tracks_date"
+            android:text="@string/sort_added_date"
             android:textAppearance="@style/TextAppearance.ZiggyMusic.White.Caption" />
 
         <ImageView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,11 +33,10 @@
     <string name="music_track_sort">음원 정렬</string>
     <string name="sort_title">제목</string>
     <string name="sort_artist">아티스트</string>
-    <string name="sort_added_to_music_tracks_date">음악 목록에 추가된 날짜</string>
+    <string name="sort_added_date">추가된 날짜</string>
     <string name="sort_ascending">오름차순</string>
     <string name="sort_descending">내림차순</string>
     <string name="sort_item_selected_description">%1$s, %2$s, 선택됨</string>
-    <string name="sort_added_to_favorite_music_tracks_date">즐겨찾기에 추가한 날짜</string>
 
     <!-- App settings -->
     <string name="settings_section_sound">사운드</string>


### PR DESCRIPTION
# PR 내용
1. `string.xml`에서 `sort_added_to_music_tracks_date` 리소스명을 `sort_added_date`로 변경하고 문구를 "추가된 날짜"로 변경
- 사용하지 않는 `sort_added_to_favorite_music_tracks_date` 문자열 리소스 삭제

2. `popup_music_track_sort_menu.xml` 내 정렬 기준 텍스트 리소스를 `sort_added_to_music_tracks_date`에서 `sort_added_date`로 변경
3. `MusicTrackSortMenuPopup` 내 정렬 기준 라벨 리소스 `dateAddedLabelResId`의 기본값을 `sort_added_to_music_tracks_date`에서 `sort_added_date`로 변경
4. `MainActivity` 내 정렬 레이블 리소스 `dateAddedLabelResId`를 `R.string.sort_added_date`로 변경